### PR TITLE
Docker image for TenSEAL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM ubuntu:19.04
+
+RUN apt update
+RUN apt install -y python3.7 python3-pip git cmake
+COPY ./ ./TenSEAL
+WORKDIR /TenSEAL
+# Get third party libraries if not present
+RUN git submodule init && git submodule update
+RUN pip3 install .

--- a/README.md
+++ b/README.md
@@ -22,6 +22,22 @@ You can then trigger the build and the installation
 $ pip install .
 ```
 
+### Use Docker
+
+![Update Docker Image](https://github.com/OpenMined/TenSEAL/workflows/Update%20Docker%20Image/badge.svg)
+
+You can use our [Docker image](https://hub.docker.com/r/openmined/tenseal) for a ready to use environment with TenSEAL installed
+
+```bash
+$ docker container run --interactive --tty openmined/tenseal
+```
+
+You can also build your custom image, this might be handy for developers working on the project
+
+```bash
+$ docker image build --tag tenseal .
+```
+
 ## Tutorials
 
 TODO


### PR DESCRIPTION
It should be helpful for devs and users to have a ready to use environment to try or use TenSEAL on. This PR add a Dockerfile for building and installing TenSEAL from the repo files and not installing a wheel package from pypi. The docker image should be updated on the Docker Hub after every push to the master branch using Github actions.