### PR TITLE
Flexible TenSEALContext

### DIFF
--- a/tenseal/__init__.py
+++ b/tenseal/__init__.py
@@ -7,6 +7,10 @@ from tenseal.version import __version__
 
 
 SCHEME_TYPE = _ts_cpp.SCHEME_TYPE
+PublicKey = _ts_cpp.PublicKey
+SecretKey = _ts_cpp.SecretKey
+RelinKeys = _ts_cpp.RelinKeys
+GaloisKeys = _ts_cpp.GaloisKeys
 
 
 def context(scheme, poly_modulus_degree, plain_modulus=None,

--- a/tenseal/binding.cpp
+++ b/tenseal/binding.cpp
@@ -163,7 +163,11 @@ PYBIND11_MODULE(_tenseal_cpp, m) {
         .def("galois_keys", &TenSEALContext::galois_keys)
         .def("is_public", &TenSEALContext::is_public)
         .def("is_private", &TenSEALContext::is_private)
-        .def("key_generator", &TenSEALContext::key_gen);
+        .def("make_context_public", &TenSEALContext::make_context_public,
+             "Generate Galois and Relinearization keys if needed, then make "
+             "then context public",
+             py::arg("generate_galois_keys") = false,
+             py::arg("generate_relin_keys") = false);
 
     // SEAL objects
 

--- a/tenseal/binding.cpp
+++ b/tenseal/binding.cpp
@@ -167,7 +167,11 @@ PYBIND11_MODULE(_tenseal_cpp, m) {
              "Generate Galois and Relinearization keys if needed, then make "
              "then context public",
              py::arg("generate_galois_keys") = false,
-             py::arg("generate_relin_keys") = false);
+             py::arg("generate_relin_keys") = false)
+        .def("generate_galois_keys", &TenSEALContext::generate_galois_keys,
+             "Generate Galois keys using the secret key")
+        .def("generate_relin_keys", &TenSEALContext::generate_relin_keys,
+             "Generate Relinearization keys using the secret key");
 
     // SEAL objects
 

--- a/tenseal/tensealcontext.cpp
+++ b/tenseal/tensealcontext.cpp
@@ -14,11 +14,17 @@ namespace tenseal {
 TenSEALContext::TenSEALContext(EncryptionParameters parms) {
     this->_parms = parms;
     this->_context = SEALContext::Create(parms);
-    this->_keygen = shared_ptr<KeyGenerator>(new KeyGenerator(this->_context));
+
+    KeyGenerator keygen = KeyGenerator(this->_context);
+
+    this->_public_key =
+        shared_ptr<PublicKey>(new PublicKey(keygen.public_key()));
+    this->_secret_key =
+        shared_ptr<SecretKey>(new SecretKey(keygen.secret_key()));
     this->encryptor = shared_ptr<Encryptor>(
-        new Encryptor(this->_context, this->public_key()));
+        new Encryptor(this->_context, *(this->_public_key)));
     this->decryptor = shared_ptr<Decryptor>(
-        new Decryptor(this->_context, this->secret_key()));
+        new Decryptor(this->_context, *(this->_secret_key)));
     this->evaluator = shared_ptr<Evaluator>(new Evaluator(this->_context));
     this->_is_public = false;
 }

--- a/tenseal/tensealcontext.cpp
+++ b/tenseal/tensealcontext.cpp
@@ -26,7 +26,6 @@ TenSEALContext::TenSEALContext(EncryptionParameters parms) {
     this->decryptor = shared_ptr<Decryptor>(
         new Decryptor(this->_context, *(this->_secret_key)));
     this->evaluator = shared_ptr<Evaluator>(new Evaluator(this->_context));
-    this->_is_public = false;
 }
 
 TenSEALContext::TenSEALContext(const char* filename) { this->load(filename); }

--- a/tenseal/tensealcontext.cpp
+++ b/tenseal/tensealcontext.cpp
@@ -22,9 +22,9 @@ TenSEALContext::TenSEALContext(EncryptionParameters parms) {
     this->_secret_key =
         shared_ptr<SecretKey>(new SecretKey(keygen.secret_key()));
     this->encryptor = shared_ptr<Encryptor>(
-        new Encryptor(this->_context, *(this->_public_key)));
+        new Encryptor(this->_context, *this->_public_key));
     this->decryptor = shared_ptr<Decryptor>(
-        new Decryptor(this->_context, *(this->_secret_key)));
+        new Decryptor(this->_context, *this->_secret_key));
     this->evaluator = shared_ptr<Evaluator>(new Evaluator(this->_context));
 }
 

--- a/tenseal/tensealcontext.h
+++ b/tenseal/tensealcontext.h
@@ -62,11 +62,62 @@ class TenSEALContext {
         return shared_ptr<TenSEALContext>(new TenSEALContext(filename));
     }
 
-    shared_ptr<KeyGenerator> key_gen() { return this->_keygen; }
-    PublicKey public_key() { return this->_keygen->public_key(); }
-    SecretKey secret_key() { return this->_keygen->secret_key(); }
-    RelinKeys relin_keys() { return this->_keygen->relin_keys(); }
-    GaloisKeys galois_keys() { return this->_keygen->galois_keys(); }
+    PublicKey public_key() { return PublicKey(*this->_public_key); }
+    SecretKey secret_key() {
+        if (this->_secret_key == nullptr) {
+            throw invalid_argument(
+                "the current context is public, it doesn't hold a Secret key");
+        }
+
+        return SecretKey(*this->_secret_key);
+    }
+
+    RelinKeys relin_keys() {
+        if (this->_relin_keys == nullptr) {
+            throw invalid_argument(
+                "the current context doesn't hold a Relinearization keys");
+        }
+
+        return RelinKeys(*this->_relin_keys);
+    }
+
+    GaloisKeys galois_keys() {
+        if (this->_galois_keys == nullptr) {
+            throw invalid_argument(
+                "the current context doesn't hold a Galois keys");
+        }
+
+        return GaloisKeys(*this->_galois_keys);
+    }
+
+    /*
+    Generate Galois and Relinearization keys if needed, then destroy the
+    _secret_key and set it to nullptr
+    */
+    void make_context_public(bool generate_galois_keys,
+                             bool generate_relin_keys) {
+        // create KeyGenerator object only if needed
+        if (generate_galois_keys || generate_relin_keys) {
+            KeyGenerator keygen = KeyGenerator(
+                this->_context, *this->_secret_key, *this->_public_key);
+
+            // generate Galois Keys
+            if (generate_galois_keys) {
+                this->_galois_keys = shared_ptr<GaloisKeys>(
+                    new GaloisKeys(keygen.galois_keys()));
+            }
+
+            // generate Relinearization Keys
+            if (generate_relin_keys) {
+                this->_relin_keys =
+                    shared_ptr<RelinKeys>(new RelinKeys(keygen.relin_keys()));
+            }
+        }
+
+        // destory and set _secret_key to null
+        this->_secret_key = nullptr;
+        this->_is_public = true;
+    }
 
     bool is_public() { return this->_is_public; }
     bool is_private() { return !this->_is_public; }
@@ -86,7 +137,10 @@ class TenSEALContext {
    private:
     EncryptionParameters _parms;
     shared_ptr<SEALContext> _context;
-    shared_ptr<KeyGenerator> _keygen;
+    shared_ptr<PublicKey> _public_key;
+    shared_ptr<SecretKey> _secret_key;
+    shared_ptr<RelinKeys> _relin_keys;
+    shared_ptr<GaloisKeys> _galois_keys;
 
     /*
     Public is when we don't hold the secret_key and can't decrypt ciphertexts.

--- a/tenseal/tensealcontext.h
+++ b/tenseal/tensealcontext.h
@@ -91,6 +91,27 @@ class TenSEALContext {
     }
 
     /*
+    Generate Galois keys using the secret key
+    */
+    void generate_galois_keys(SecretKey secret_key) {
+        KeyGenerator keygen =
+            KeyGenerator(this->_context, secret_key, *this->_public_key);
+
+        this->_galois_keys =
+            shared_ptr<GaloisKeys>(new GaloisKeys(keygen.galois_keys()));
+    }
+
+    /*
+    Generate Relinearization keys using the secret key
+    */
+    void generate_relin_keys(SecretKey secret_key) {
+        KeyGenerator keygen =
+            KeyGenerator(this->_context, secret_key, *this->_public_key);
+        this->_relin_keys =
+            shared_ptr<RelinKeys>(new RelinKeys(keygen.relin_keys()));
+    }
+
+    /*
     Generate Galois and Relinearization keys if needed, then destroy the
     _secret_key and set it to nullptr
     */

--- a/tenseal/tensealcontext.h
+++ b/tenseal/tensealcontext.h
@@ -114,8 +114,9 @@ class TenSEALContext {
             }
         }
 
-        // destory and set _secret_key to null
+        // destory and set _secret_key and decryptor to null
         this->_secret_key = nullptr;
+        this->decryptor = nullptr;
         this->_is_public = true;
     }
 

--- a/tenseal/tensealcontext.h
+++ b/tenseal/tensealcontext.h
@@ -117,11 +117,10 @@ class TenSEALContext {
         // destory and set _secret_key and decryptor to null
         this->_secret_key = nullptr;
         this->decryptor = nullptr;
-        this->_is_public = true;
     }
 
-    bool is_public() { return this->_is_public; }
-    bool is_private() { return !this->_is_public; }
+    bool is_public() { return this->_secret_key == nullptr; }
+    bool is_private() { return this->_secret_key != nullptr; }
 
     /*
     Save the attributes needed to restore the context later, public is for not
@@ -142,11 +141,6 @@ class TenSEALContext {
     shared_ptr<SecretKey> _secret_key;
     shared_ptr<RelinKeys> _relin_keys;
     shared_ptr<GaloisKeys> _galois_keys;
-
-    /*
-    Public is when we don't hold the secret_key and can't decrypt ciphertexts.
-    */
-    bool _is_public;
 
     TenSEALContext(EncryptionParameters parms);
     TenSEALContext(const char* filename);

--- a/tenseal/tensealcontext.h
+++ b/tenseal/tensealcontext.h
@@ -62,14 +62,14 @@ class TenSEALContext {
         return shared_ptr<TenSEALContext>(new TenSEALContext(filename));
     }
 
-    PublicKey public_key() { return PublicKey(*this->_public_key); }
+    PublicKey public_key() { return *this->_public_key; }
     SecretKey secret_key() {
         if (this->_secret_key == nullptr) {
             throw invalid_argument(
                 "the current context is public, it doesn't hold a Secret key");
         }
 
-        return SecretKey(*this->_secret_key);
+        return *this->_secret_key;
     }
 
     RelinKeys relin_keys() {
@@ -78,7 +78,7 @@ class TenSEALContext {
                 "the current context doesn't hold a Relinearization keys");
         }
 
-        return RelinKeys(*this->_relin_keys);
+        return *this->_relin_keys;
     }
 
     GaloisKeys galois_keys() {
@@ -87,7 +87,7 @@ class TenSEALContext {
                 "the current context doesn't hold a Galois keys");
         }
 
-        return GaloisKeys(*this->_galois_keys);
+        return *this->_galois_keys;
     }
 
     /*

--- a/tests/test_tensealcontext.py
+++ b/tests/test_tensealcontext.py
@@ -1,0 +1,37 @@
+import tenseal as ts
+
+
+def test_context_creation():
+    context = ts.context(ts.SCHEME_TYPE.BFV, 8192, 1032193)
+
+    assert context.is_private() is True, "TenSEALContext should be private"
+    assert context.public_key() is not None, "TenSEALContext shouldn't be None"
+
+
+def test_make_context_public():
+    context = ts.context(ts.SCHEME_TYPE.BFV, 8192, 1032193)
+    context.make_context_public(
+        generate_galois_keys=False, generate_relin_keys=False)
+    assert context.is_public() is True, "TenSEALContext should be public"
+
+
+def test_generate_galois_keys():
+    context = ts.context(ts.SCHEME_TYPE.BFV, 8192, 1032193)
+    secret_key = context.secret_key()
+    context.make_context_public(
+        generate_galois_keys=False, generate_relin_keys=False)
+
+    context.generate_galois_keys(secret_key)
+    assert type(context.galois_keys()
+                ) is ts.GaloisKeys, "Galois keys should be set"
+
+
+def test_generate_relin_keys():
+    context = ts.context(ts.SCHEME_TYPE.BFV, 8192, 1032193)
+    secret_key = context.secret_key()
+    context.make_context_public(
+        generate_galois_keys=False, generate_relin_keys=False)
+
+    context.generate_relin_keys(secret_key)
+    assert type(context.relin_keys()
+                ) is ts.RelinKeys, "Relin keys should be set"


### PR DESCRIPTION
This PR modify the TenSEALContext class and its behaviors according to Keys Generations.
The KeyGenerator object is no longer an attribute, instead there's a pointer for each key (Public, Secret, Galois and Relinearization keys).
During constructing a TenSEALContext object we create a KeyGenerator object in order to generate a public and secret keys and making encrypter and decrypter.
There's a new method `make_context_public`, it will generate the Galois and Relinearization keys if needed, then make the context public, by destroying the secret key and the decryptor and setting them to `nullptr`.