### PR TITLE
Publishing workflow for macOS

### DIFF
--- a/.github/workflows/pythonpublish-macos.yml
+++ b/.github/workflows/pythonpublish-macos.yml
@@ -28,12 +28,11 @@ jobs:
         python -m pip install --upgrade pip
         pip install setuptools wheel twine auditwheel
     - name: Build and publish
-      #env:
-        #TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        #TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
         # fetch third party libraries
         git submodule init && git submodule update
         pip wheel . -w wheel/
-        auditwheel repair wheel/*.whl -w wheel/
         twine upload wheel/*

--- a/.github/workflows/pythonpublish-macos.yml
+++ b/.github/workflows/pythonpublish-macos.yml
@@ -1,0 +1,39 @@
+# This workflows will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+name: MacOS Package
+
+on:
+  release:
+    types: [created]
+  pull_request:
+    types: [ opened, synchronize, reopened ]
+
+jobs:
+  deploy:
+
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine auditwheel
+    - name: Build and publish
+      #env:
+        #TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        #TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        # fetch third party libraries
+        git submodule init && git submodule update
+        pip wheel . -w wheel/
+        auditwheel repair wheel/*.whl -w wheel/
+        twine upload wheel/*

--- a/.github/workflows/pythonpublish-macos.yml
+++ b/.github/workflows/pythonpublish-macos.yml
@@ -1,13 +1,8 @@
-# This workflows will upload a Python Package using Twine when a release is created
-# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
-
 name: MacOS Package
 
 on:
   release:
     types: [created]
-  pull_request:
-    types: [ opened, synchronize, reopened ]
 
 jobs:
   deploy:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # TenSEAL
 
+![MacOS Package](https://github.com/OpenMined/TenSEAL/workflows/MacOS%20Package/badge.svg)
 ![Tests](https://github.com/OpenMined/TenSEAL/workflows/Tests/badge.svg)
 ![Update Docker Image](https://github.com/OpenMined/TenSEAL/workflows/Update%20Docker%20Image/badge.svg)
 


### PR DESCRIPTION
Build and push wheels for macOS Catalina, I don't know if this should be backward compatible, but at least we now support the latest version of macOS.

#11 #17 