### PR TITLE
Fix transparent ciphertext for CKKS and BFV vectors

### DIFF
--- a/tenseal/tensors/bfvvector.cpp
+++ b/tenseal/tensors/bfvvector.cpp
@@ -189,6 +189,8 @@ BFVVector& BFVVector::mul_plain_inplace(vector<int64_t> to_mul) {
 
     BatchEncoder batch_encoder(this->context->seal_context());
     Plaintext plaintext;
+    // prevent transparent ciphertext by adding a non-zero value
+    if (to_mul.size() + 1 <= batch_encoder.slot_count()) to_mul.push_back(1);
     batch_encoder.encode(to_mul, plaintext);
 
     this->context->evaluator->multiply_plain_inplace(this->ciphertext,

--- a/tenseal/tensors/ckksvector.cpp
+++ b/tenseal/tensors/ckksvector.cpp
@@ -186,6 +186,8 @@ CKKSVector& CKKSVector::mul_plain_inplace(vector<double> to_mul) {
 
     CKKSEncoder encoder(this->context->seal_context());
     Plaintext plaintext;
+    // prevent transparent ciphertext by adding a non-zero value
+    if (to_mul.size() + 1 <= encoder.slot_count()) to_mul.push_back(1);
     encoder.encode(to_mul, this->init_scale, plaintext);
     this->context->evaluator->multiply_plain_inplace(this->ciphertext,
                                                      plaintext);


### PR DESCRIPTION
### Problem

Multipying a CKKS or BFV vector with a plain vector of all zeros will result in a transparent ciphertext.

### Solution

We take advantage of the fact that we don't always use all the slots available, so we add an additional non-zero value to our plaintext vector before encoding, which means that we will be multiplying with our initial vector with an appended non-zero value. This won't affect our used slots since operations are done element-wise and the size of our vector (logical size) will still remain the same, and decryption won't take the additional used slot into consideration.