### PR TITLE
fix bfv-naive-vector decrypt function

### DIFF
--- a/tenseal/tensors/bfvnaivevector.cpp
+++ b/tenseal/tensors/bfvnaivevector.cpp
@@ -39,7 +39,7 @@ streamoff BFVNaiveVector::save_size() {
     return sum_save_size;
 }
 
-vector<int> BFVNaiveVector::decrypt() {
+vector<int64_t> BFVNaiveVector::decrypt() {
     if (this->context->decryptor == NULL) {
         // this->context was loaded with public keys only
         throw invalid_argument(
@@ -50,12 +50,12 @@ vector<int> BFVNaiveVector::decrypt() {
     return this->decrypt(this->context->secret_key());
 }
 
-vector<int> BFVNaiveVector::decrypt(SecretKey sk) {
+vector<int64_t> BFVNaiveVector::decrypt(SecretKey sk) {
     Plaintext plaintext;
     IntegerEncoder encoder(this->context->seal_context());
     Decryptor decryptor = Decryptor(this->context->seal_context(), sk);
 
-    vector<int> result;
+    vector<int64_t> result;
     result.reserve(this->ciphertexts.size());
 
     for (int i = 0; i < this->ciphertexts.size(); i++) {

--- a/tenseal/tensors/bfvnaivevector.h
+++ b/tenseal/tensors/bfvnaivevector.h
@@ -27,8 +27,8 @@ class BFVNaiveVector {
     Decrypts and returns the plaintext representation of the encrypted vector of
     integers using the secret-key.
     */
-    vector<int> decrypt();
-    vector<int> decrypt(SecretKey sk);
+    vector<int64_t> decrypt();
+    vector<int64_t> decrypt(SecretKey sk);
 
     /*
     Returns the size of the encrypted vector.


### PR DESCRIPTION
Since `seal::IntegerEncoder::decode_int64` decodes and return result as `std::int64_t`, we should use `std::int64_t` data type for decrypted the result in `BFVNaiveVector::decrypt` function.