### PR TITLE
Relinearize CKKSVector after every ct-ct multiplication

### DIFF
--- a/tenseal/binding.cpp
+++ b/tenseal/binding.cpp
@@ -168,9 +168,13 @@ PYBIND11_MODULE(_tenseal_cpp, m) {
              "then context public",
              py::arg("generate_galois_keys") = false,
              py::arg("generate_relin_keys") = false)
-        .def("generate_galois_keys", &TenSEALContext::generate_galois_keys,
+        .def("generate_galois_keys", py::overload_cast<>(&TenSEALContext::generate_galois_keys),
              "Generate Galois keys using the secret key")
-        .def("generate_relin_keys", &TenSEALContext::generate_relin_keys,
+        .def("generate_galois_keys", py::overload_cast<SecretKey>(&TenSEALContext::generate_galois_keys),
+             "Generate Galois keys using the secret key")
+        .def("generate_relin_keys", py::overload_cast<>(&TenSEALContext::generate_relin_keys),
+             "Generate Relinearization keys using the secret key")
+        .def("generate_relin_keys", py::overload_cast<SecretKey>(&TenSEALContext::generate_relin_keys),
              "Generate Relinearization keys using the secret key");
 
     // SEAL objects

--- a/tenseal/binding.cpp
+++ b/tenseal/binding.cpp
@@ -168,13 +168,18 @@ PYBIND11_MODULE(_tenseal_cpp, m) {
              "then context public",
              py::arg("generate_galois_keys") = false,
              py::arg("generate_relin_keys") = false)
-        .def("generate_galois_keys", py::overload_cast<>(&TenSEALContext::generate_galois_keys),
+        .def("generate_galois_keys",
+             py::overload_cast<>(&TenSEALContext::generate_galois_keys),
              "Generate Galois keys using the secret key")
-        .def("generate_galois_keys", py::overload_cast<SecretKey>(&TenSEALContext::generate_galois_keys),
-             "Generate Galois keys using the secret key")
-        .def("generate_relin_keys", py::overload_cast<>(&TenSEALContext::generate_relin_keys),
+        .def(
+            "generate_galois_keys",
+            py::overload_cast<SecretKey>(&TenSEALContext::generate_galois_keys),
+            "Generate Galois keys using the secret key")
+        .def("generate_relin_keys",
+             py::overload_cast<>(&TenSEALContext::generate_relin_keys),
              "Generate Relinearization keys using the secret key")
-        .def("generate_relin_keys", py::overload_cast<SecretKey>(&TenSEALContext::generate_relin_keys),
+        .def("generate_relin_keys",
+             py::overload_cast<SecretKey>(&TenSEALContext::generate_relin_keys),
              "Generate Relinearization keys using the secret key");
 
     // SEAL objects

--- a/tenseal/tensealcontext.cpp
+++ b/tenseal/tensealcontext.cpp
@@ -26,6 +26,8 @@ TenSEALContext::TenSEALContext(EncryptionParameters parms) {
     this->decryptor = shared_ptr<Decryptor>(
         new Decryptor(this->_context, *this->_secret_key));
     this->evaluator = shared_ptr<Evaluator>(new Evaluator(this->_context));
+    // TODO: can make this optional
+    this->generate_relin_keys();
 }
 
 TenSEALContext::TenSEALContext(const char* filename) { this->load(filename); }

--- a/tenseal/tensealcontext.h
+++ b/tenseal/tensealcontext.h
@@ -94,10 +94,9 @@ class TenSEALContext {
     Generate Galois keys using the secret key
     */
     void generate_galois_keys() {
-        if (this->is_public()){
+        if (this->is_public()) {
             throw invalid_argument("you need to provide a secret_key");
-        }
-        else {
+        } else {
             this->generate_galois_keys(*this->_secret_key);
         }
     }
@@ -113,10 +112,9 @@ class TenSEALContext {
     Generate Relinearization keys using the secret key
     */
     void generate_relin_keys() {
-        if (this->is_public()){
+        if (this->is_public()) {
             throw invalid_argument("you need to provide a secret_key");
-        }
-        else {
+        } else {
             this->generate_relin_keys(*this->_secret_key);
         }
     }

--- a/tenseal/tensealcontext.h
+++ b/tenseal/tensealcontext.h
@@ -93,6 +93,15 @@ class TenSEALContext {
     /*
     Generate Galois keys using the secret key
     */
+    void generate_galois_keys() {
+        if (this->is_public()){
+            throw invalid_argument("you need to provide a secret_key");
+        }
+        else {
+            this->generate_galois_keys(*this->_secret_key);
+        }
+    }
+
     void generate_galois_keys(SecretKey secret_key) {
         KeyGenerator keygen = KeyGenerator(this->_context, secret_key);
 
@@ -103,6 +112,15 @@ class TenSEALContext {
     /*
     Generate Relinearization keys using the secret key
     */
+    void generate_relin_keys() {
+        if (this->is_public()){
+            throw invalid_argument("you need to provide a secret_key");
+        }
+        else {
+            this->generate_relin_keys(*this->_secret_key);
+        }
+    }
+
     void generate_relin_keys(SecretKey secret_key) {
         KeyGenerator keygen = KeyGenerator(this->_context, secret_key);
         this->_relin_keys =

--- a/tenseal/tensors/ckksvector.cpp
+++ b/tenseal/tensors/ckksvector.cpp
@@ -169,6 +169,10 @@ CKKSVector& CKKSVector::mul_inplace(CKKSVector to_mul) {
     this->context->evaluator->multiply_inplace(this->ciphertext,
                                                to_mul.ciphertext);
 
+    // relineraize after ciphertext-ciphertext multiplication
+    this->context->evaluator->relinearize_inplace(this->ciphertext,
+                                                  this->context->relin_keys());
+
     return *this;
 }
 

--- a/tenseal/tensors/ckksvector.cpp
+++ b/tenseal/tensors/ckksvector.cpp
@@ -169,6 +169,7 @@ CKKSVector& CKKSVector::mul_inplace(CKKSVector to_mul) {
     this->context->evaluator->multiply_inplace(this->ciphertext,
                                                to_mul.ciphertext);
 
+    // TODO: can make this optional
     // relineraize after ciphertext-ciphertext multiplication
     this->context->evaluator->relinearize_inplace(this->ciphertext,
                                                   this->context->relin_keys());

--- a/tests/tensors/test_ckks_vector.py
+++ b/tests/tensors/test_ckks_vector.py
@@ -15,7 +15,10 @@ def _almost_equal(vec1, vec2, m_pow_ten):
 
 @pytest.fixture(scope="module")
 def context():
-    return ts.context(ts.SCHEME_TYPE.CKKS, 8192, coeff_mod_bit_sizes=[60, 40, 40, 60])
+    context = ts.context(ts.SCHEME_TYPE.CKKS, 8192, coeff_mod_bit_sizes=[60, 40, 40, 60])
+    # we need to generate relin_keys for performing multiplication
+    context.generate_relin_keys()
+    return context
 
 
 @pytest.fixture(scope="module")

--- a/tests/tensors/test_ckks_vector.py
+++ b/tests/tensors/test_ckks_vector.py
@@ -15,10 +15,7 @@ def _almost_equal(vec1, vec2, m_pow_ten):
 
 @pytest.fixture(scope="module")
 def context():
-    context = ts.context(ts.SCHEME_TYPE.CKKS, 8192, coeff_mod_bit_sizes=[60, 40, 40, 60])
-    # we need to generate relin_keys for performing multiplication
-    context.generate_relin_keys()
-    return context
+    return ts.context(ts.SCHEME_TYPE.CKKS, 8192, coeff_mod_bit_sizes=[60, 40, 40, 60])
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
As we should normally re-linearize after every ct-ct multiplication, I think we should do it by default in tensor operations (we can make it optional if users still wants the ability to turn it off).

This PR also overload both `generate_[relin|galois]_keys` to generate them without providing a SecretKey in case of a private context (which already holds the secret_key).

Related #35 
