### PR TITLE
CKKSVector matrix multiplciation

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,7 +1,8 @@
 black>=10.3b0
 bumpversion>=0.5.3
 flake8
+numpy
 pytest>=5.4.1
-setuptools>=41.0.0
 pytest-benchmark
 pytest-benchmark[histogram]
+setuptools>=41.0.0

--- a/tenseal/binding.cpp
+++ b/tenseal/binding.cpp
@@ -124,6 +124,7 @@ PYBIND11_MODULE(_tenseal_cpp, m) {
         .def("mul_", &CKKSVector::mul_inplace)
         .def("mul_plain", &CKKSVector::mul_plain)
         .def("mul_plain_", &CKKSVector::mul_plain_inplace)
+        .def("matmul", &CKKSVector::matmul_right)
         // python arithmetic
         .def("__add__", &CKKSVector::add)
         .def("__add__", &CKKSVector::add_plain)

--- a/tenseal/binding.cpp
+++ b/tenseal/binding.cpp
@@ -124,8 +124,10 @@ PYBIND11_MODULE(_tenseal_cpp, m) {
         .def("mul_", &CKKSVector::mul_inplace)
         .def("mul_plain", &CKKSVector::mul_plain)
         .def("mul_plain_", &CKKSVector::mul_plain_inplace)
-        .def("matmul", &CKKSVector::matmul_right)
-        .def("mm", &CKKSVector::matmul_right)
+        .def("matmul", &CKKSVector::matmul)
+        .def("matmul_", &CKKSVector::matmul_inplace)
+        .def("mm", &CKKSVector::matmul)
+        .def("mm_", &CKKSVector::matmul_inplace)
         // python arithmetic
         .def("__add__", &CKKSVector::add)
         .def("__add__", &CKKSVector::add_plain)
@@ -139,7 +141,8 @@ PYBIND11_MODULE(_tenseal_cpp, m) {
         .def("__mul__", &CKKSVector::mul_plain)
         .def("__imul__", &CKKSVector::mul_inplace)
         .def("__imul__", &CKKSVector::mul_plain_inplace)
-        .def("__matmul__", &CKKSVector::matmul_right);
+        .def("__matmul__", &CKKSVector::matmul)
+        .def("__imatmul__", &CKKSVector::matmul_inplace);
 
     py::class_<TenSEALContext, std::shared_ptr<TenSEALContext>>(
         m, "TenSEALContext")

--- a/tenseal/binding.cpp
+++ b/tenseal/binding.cpp
@@ -125,6 +125,7 @@ PYBIND11_MODULE(_tenseal_cpp, m) {
         .def("mul_plain", &CKKSVector::mul_plain)
         .def("mul_plain_", &CKKSVector::mul_plain_inplace)
         .def("matmul", &CKKSVector::matmul_right)
+        .def("mm", &CKKSVector::matmul_right)
         // python arithmetic
         .def("__add__", &CKKSVector::add)
         .def("__add__", &CKKSVector::add_plain)
@@ -137,7 +138,8 @@ PYBIND11_MODULE(_tenseal_cpp, m) {
         .def("__mul__", &CKKSVector::mul)
         .def("__mul__", &CKKSVector::mul_plain)
         .def("__imul__", &CKKSVector::mul_inplace)
-        .def("__imul__", &CKKSVector::mul_plain_inplace);
+        .def("__imul__", &CKKSVector::mul_plain_inplace)
+        .def("__matmul__", &CKKSVector::matmul_right);
 
     py::class_<TenSEALContext, std::shared_ptr<TenSEALContext>>(
         m, "TenSEALContext")

--- a/tenseal/binding.cpp
+++ b/tenseal/binding.cpp
@@ -124,10 +124,10 @@ PYBIND11_MODULE(_tenseal_cpp, m) {
         .def("mul_", &CKKSVector::mul_inplace)
         .def("mul_plain", &CKKSVector::mul_plain)
         .def("mul_plain_", &CKKSVector::mul_plain_inplace)
-        .def("matmul", &CKKSVector::matmul)
-        .def("matmul_", &CKKSVector::matmul_inplace)
-        .def("mm", &CKKSVector::matmul)
-        .def("mm_", &CKKSVector::matmul_inplace)
+        .def("matmul", &CKKSVector::matmul_plain)
+        .def("matmul_", &CKKSVector::matmul_plain_inplace)
+        .def("mm", &CKKSVector::matmul_plain)
+        .def("mm_", &CKKSVector::matmul_plain_inplace)
         // python arithmetic
         .def("__add__", &CKKSVector::add)
         .def("__add__", &CKKSVector::add_plain)
@@ -141,8 +141,8 @@ PYBIND11_MODULE(_tenseal_cpp, m) {
         .def("__mul__", &CKKSVector::mul_plain)
         .def("__imul__", &CKKSVector::mul_inplace)
         .def("__imul__", &CKKSVector::mul_plain_inplace)
-        .def("__matmul__", &CKKSVector::matmul)
-        .def("__imatmul__", &CKKSVector::matmul_inplace);
+        .def("__matmul__", &CKKSVector::matmul_plain)
+        .def("__imatmul__", &CKKSVector::matmul_plain_inplace);
 
     py::class_<TenSEALContext, std::shared_ptr<TenSEALContext>>(
         m, "TenSEALContext")

--- a/tenseal/matrix_ops.h
+++ b/tenseal/matrix_ops.h
@@ -15,8 +15,9 @@ using namespace std;
 /*
 Returns the k-th diagonal of a matrix. Positive values of k represent upper
 diagonals while negative values represent lower diagonal with 0 being the main
-diagonal. It's important to note that diagonals here are of the size of the
-matrix, we rotate as we reach the boundaries of the matrix.
+diagonal. It's important to note that diagonals are extended to fit the size of
+the matrix, we do that by rotating whenever we reach the boundaries of the
+matrix.
 */
 template <typename T>
 vector<T> get_diagonal(const vector<vector<T>>& matrix, int k) {

--- a/tenseal/matrix_ops.h
+++ b/tenseal/matrix_ops.h
@@ -1,0 +1,93 @@
+#ifndef TENSEAL_MATRIX_OPS_H
+#define TENSEAL_MATRIX_OPS_H
+
+#include <seal/seal.h>
+
+#include <memory>
+
+#include "tensealcontext.h"
+
+namespace tenseal {
+
+using namespace seal;
+using namespace std;
+
+/*
+Returns the k-th diagonal of a matrix. Positive values of k represent upper
+diagonals while negative values represent lower diagonal with 0 being the main
+diagonal. It's important to note that diagonals here are of the size of the
+matrix, we rotate as we reach the boundaries of the matrix.
+*/
+template <typename T>
+vector<T> get_diagonal(const vector<vector<T>>& matrix, int k) {
+    size_t n_rows = matrix.size();
+    size_t n_cols = matrix[0].size();
+
+    vector<double> t_diag;
+    t_diag.reserve(n_rows * n_cols);
+
+    size_t r_offset = 0, c_offset = 0;
+    if (k > 0) {  // upper diagonals
+        c_offset = k;
+    } else {  // lower diagonal
+        r_offset = -k;
+    }
+
+    for (size_t i = 0; i < n_rows * n_cols; i++) {
+        t_diag.push_back(
+            matrix[(r_offset + i) % n_rows][(c_offset + i) % n_cols]);
+    }
+
+    return t_diag;
+}
+
+/*
+Perform encrypted_vector-plain_matrix multiplication using a variant of the
+diagonal method of Halevi and Shoup [1].
+
+[1] Halevi, S., & Shoup, V. (2014, August). Algorithms in helib. In Annual
+Cryptology Conference (pp. 554-571). Springer, Berlin, Heidelberg.
+*/
+template <typename T, class Encoder>
+Ciphertext diagonal_ct_vector_matmul(shared_ptr<TenSEALContext> tenseal_context,
+                                     const Ciphertext& vec, size_t vector_size,
+                                     const vector<vector<T>>& matrix) {
+    // matrix is organized by rows
+    // _check_matrix(matrix, this->size())
+    size_t n_rows = matrix.size();
+    size_t n_cols = matrix[0].size();
+
+    if (vector_size != matrix.size()) {
+        throw invalid_argument("matrix shape doesn't match with vector size");
+    }
+
+    vector<Ciphertext> results;
+    Ciphertext result;
+    results.reserve(n_rows);
+
+    for (size_t i = 0; i < n_rows; i++) {
+        Ciphertext ct;
+        Plaintext pt_diag;
+        vector<T> diag;
+
+        diag = get_diagonal(matrix, -i);
+        replicate_vector(diag,
+                         tenseal_context->get_encoder<Encoder>()->slot_count());
+
+        rotate(diag.begin(), diag.begin() + diag.size() - i, diag.end());
+
+        tenseal_context->encode<double, Encoder>(diag, pt_diag);
+        tenseal_context->evaluator->multiply_plain(vec, pt_diag, ct);
+        tenseal_context->evaluator->rotate_vector_inplace(
+            ct, i, tenseal_context->galois_keys());
+        results.push_back(ct);
+    }
+
+    tenseal_context->evaluator->add_many(results, result);
+
+    return result;
+}
+
+}  // namespace tenseal
+
+#endif

--- a/tenseal/matrix_ops.h
+++ b/tenseal/matrix_ops.h
@@ -76,7 +76,7 @@ Ciphertext diagonal_ct_vector_matmul(shared_ptr<TenSEALContext> tenseal_context,
 
         rotate(diag.begin(), diag.begin() + diag.size() - i, diag.end());
 
-        tenseal_context->encode<double, Encoder>(diag, pt_diag);
+        tenseal_context->encode<Encoder>(diag, pt_diag);
         tenseal_context->evaluator->multiply_plain(vec, pt_diag, ct);
         tenseal_context->evaluator->rotate_vector_inplace(
             ct, i, tenseal_context->galois_keys());

--- a/tenseal/tensealcontext.h
+++ b/tenseal/tensealcontext.h
@@ -176,6 +176,19 @@ class TenSEALContext {
         return encoder_factory->get<T>();
     }
 
+    template <typename T, class Encoder>
+    void encode(vector<T>& vec, Plaintext& pt) {
+        if (std::is_same<Encoder, CKKSEncoder>::value) {
+            auto scale = pow(2.0, 40);
+            auto encoder = this->get_encoder<Encoder>();
+            encoder->encode(vec, scale, pt);
+        } else {
+            auto scale = pow(2.0, 40);
+            auto encoder = this->get_encoder<Encoder>();
+            encoder->encode(vec, scale, pt);
+        }
+    }
+
    private:
     EncryptionParameters _parms;
     shared_ptr<SEALContext> _context;

--- a/tenseal/tensealcontext.h
+++ b/tenseal/tensealcontext.h
@@ -176,17 +176,21 @@ class TenSEALContext {
         return encoder_factory->get<T>();
     }
 
-    template <typename T, class Encoder>
-    void encode(vector<T>& vec, Plaintext& pt) {
-        if (std::is_same<Encoder, CKKSEncoder>::value) {
-            auto scale = pow(2.0, 40);
-            auto encoder = this->get_encoder<Encoder>();
-            encoder->encode(vec, scale, pt);
-        } else {
-            auto scale = pow(2.0, 40);
-            auto encoder = this->get_encoder<Encoder>();
-            encoder->encode(vec, scale, pt);
-        }
+    /*
+    Template encoding functions to choose between the use of BatchEncoder or
+    CKKSEncoder.
+    */
+    template <class BatchEncoder>
+    void encode(vector<int64_t>& vec, Plaintext& pt) {
+        auto encoder = this->get_encoder<BatchEncoder>();
+        encoder->encode(vec, pt);
+    }
+
+    template <class CKKSEncoder>
+    void encode(vector<double>& vec, Plaintext& pt, double scale = 0) {
+        if (scale == 0) scale = pow(2, 40);  // TODO: get from TenSEALContext
+        auto encoder = this->get_encoder<CKKSEncoder>();
+        encoder->encode(vec, scale, pt);
     }
 
    private:

--- a/tenseal/tensors/ckksvector.cpp
+++ b/tenseal/tensors/ckksvector.cpp
@@ -202,12 +202,12 @@ CKKSVector& CKKSVector::mul_plain_inplace(vector<double> to_mul) {
     return *this;
 }
 
-CKKSVector CKKSVector::matmul(const vector<vector<double>>& matrix) {
+CKKSVector CKKSVector::matmul_plain(const vector<vector<double>>& matrix) {
     CKKSVector new_vector = *this;
-    return new_vector.matmul_inplace(matrix);
+    return new_vector.matmul_plain_inplace(matrix);
 }
 
-CKKSVector& CKKSVector::matmul_inplace(const vector<vector<double>>& matrix) {
+CKKSVector& CKKSVector::matmul_plain_inplace(const vector<vector<double>>& matrix) {
     this->ciphertext = diagonal_ct_vector_matmul<double, CKKSEncoder>(
         this->context, this->ciphertext, this->size(), matrix);
 

--- a/tenseal/tensors/ckksvector.cpp
+++ b/tenseal/tensors/ckksvector.cpp
@@ -213,7 +213,7 @@ CKKSVector CKKSVector::matmul_right(const vector<vector<double>> matrix) {
     }
 
     CKKSVector result_vector = *this;
-    CKKSEncoder encoder(this->context->seal_context());
+    auto encoder = this->context->get_encoder<CKKSEncoder>();
 
     Ciphertext ct;
     Plaintext pt_diag;
@@ -223,11 +223,11 @@ CKKSVector CKKSVector::matmul_right(const vector<vector<double>> matrix) {
 
     for (size_t i = 0; i < n_rows; i++) {
         diag = get_diagonal(matrix, -i);
-        replicate_vector(diag, encoder.slot_count());
+        replicate_vector(diag, encoder->slot_count());
 
         rotate(diag.begin(), diag.begin() + diag.size() - i, diag.end());
 
-        encoder.encode(diag, this->init_scale, pt_diag);
+        encoder->encode(diag, this->init_scale, pt_diag);
         this->context->evaluator->multiply_plain(this->ciphertext, pt_diag, ct);
         // TODO: relin and rescale
         this->context->evaluator->rotate_vector_inplace(

--- a/tenseal/tensors/ckksvector.cpp
+++ b/tenseal/tensors/ckksvector.cpp
@@ -212,9 +212,7 @@ CKKSVector& CKKSVector::matmul_inplace(const vector<vector<double>>& matrix) {
         this->context, this->ciphertext, this->size(), matrix);
 
     this->_size = matrix[0].size();
-    // TODO: relin and rescale (optional)
-    this->context->evaluator->relinearize_inplace(this->ciphertext,
-                                                  this->context->relin_keys());
+    // TODO: rescale (optional)
     return *this;
 }
 

--- a/tenseal/tensors/ckksvector.cpp
+++ b/tenseal/tensors/ckksvector.cpp
@@ -219,13 +219,14 @@ CKKSVector& CKKSVector::matmul_inplace(const vector<vector<double>>& matrix) {
 
     auto encoder = this->context->get_encoder<CKKSEncoder>();
 
-    Ciphertext ct;
-    Plaintext pt_diag;
-    vector<double> diag;
     vector<Ciphertext> results;
     results.reserve(n_rows);
 
     for (size_t i = 0; i < n_rows; i++) {
+        Ciphertext ct;
+        Plaintext pt_diag;
+        vector<double> diag;
+
         diag = get_diagonal(matrix, -i);
         replicate_vector(diag, encoder->slot_count());
 

--- a/tenseal/tensors/ckksvector.cpp
+++ b/tenseal/tensors/ckksvector.cpp
@@ -201,12 +201,12 @@ CKKSVector& CKKSVector::mul_plain_inplace(vector<double> to_mul) {
     return *this;
 }
 
-CKKSVector CKKSVector::matmul(const vector<vector<double>> matrix) {
+CKKSVector CKKSVector::matmul(const vector<vector<double>>& matrix) {
     CKKSVector new_vector = *this;
     return new_vector.matmul_inplace(matrix);
 }
 
-CKKSVector& CKKSVector::matmul_inplace(const vector<vector<double>> matrix) {
+CKKSVector& CKKSVector::matmul_inplace(const vector<vector<double>>& matrix) {
     // matrix is organized by rows
     // _check_matrix(matrix, this->size())
     size_t n_rows = matrix.size();

--- a/tenseal/tensors/ckksvector.cpp
+++ b/tenseal/tensors/ckksvector.cpp
@@ -210,10 +210,11 @@ CKKSVector CKKSVector::matmul(const vector<vector<double>>& matrix) {
 CKKSVector& CKKSVector::matmul_inplace(const vector<vector<double>>& matrix) {
     this->ciphertext = diagonal_ct_vector_matmul<double, CKKSEncoder>(
         this->context, this->ciphertext, this->size(), matrix);
-    
-    this->_size = matrix[0].size();;
-    // TODO: relin and rescale
 
+    this->_size = matrix[0].size();
+    // TODO: relin and rescale (optional)
+    this->context->evaluator->relinearize_inplace(this->ciphertext,
+                                                  this->context->relin_keys());
     return *this;
 }
 

--- a/tenseal/tensors/ckksvector.cpp
+++ b/tenseal/tensors/ckksvector.cpp
@@ -207,7 +207,8 @@ CKKSVector CKKSVector::matmul_plain(const vector<vector<double>>& matrix) {
     return new_vector.matmul_plain_inplace(matrix);
 }
 
-CKKSVector& CKKSVector::matmul_plain_inplace(const vector<vector<double>>& matrix) {
+CKKSVector& CKKSVector::matmul_plain_inplace(
+    const vector<vector<double>>& matrix) {
     this->ciphertext = diagonal_ct_vector_matmul<double, CKKSEncoder>(
         this->context, this->ciphertext, this->size(), matrix);
 

--- a/tenseal/tensors/ckksvector.cpp
+++ b/tenseal/tensors/ckksvector.cpp
@@ -201,7 +201,12 @@ CKKSVector& CKKSVector::mul_plain_inplace(vector<double> to_mul) {
     return *this;
 }
 
-CKKSVector CKKSVector::matmul_right(const vector<vector<double>> matrix) {
+CKKSVector CKKSVector::matmul(const vector<vector<double>> matrix) {
+    CKKSVector new_vector = *this;
+    return new_vector.matmul_inplace(matrix);
+}
+
+CKKSVector& CKKSVector::matmul_inplace(const vector<vector<double>> matrix) {
     // matrix is organized by rows
     // _check_matrix(matrix, this->size())
     size_t n_rows = matrix.size();
@@ -212,7 +217,6 @@ CKKSVector CKKSVector::matmul_right(const vector<vector<double>> matrix) {
         throw invalid_argument("matrix shape doesn't match with vector size");
     }
 
-    CKKSVector result_vector = *this;
     auto encoder = this->context->get_encoder<CKKSEncoder>();
 
     Ciphertext ct;
@@ -235,10 +239,10 @@ CKKSVector CKKSVector::matmul_right(const vector<vector<double>> matrix) {
         results.push_back(ct);
     }
 
-    this->context->evaluator->add_many(results, result_vector.ciphertext);
-    result_vector._size = n_cols;
+    this->context->evaluator->add_many(results, this->ciphertext);
+    this->_size = n_cols;
 
-    return result_vector;
+    return *this;
 }
 
 }  // namespace tenseal

--- a/tenseal/tensors/ckksvector.cpp
+++ b/tenseal/tensors/ckksvector.cpp
@@ -234,7 +234,6 @@ CKKSVector& CKKSVector::matmul_inplace(const vector<vector<double>>& matrix) {
 
         encoder->encode(diag, this->init_scale, pt_diag);
         this->context->evaluator->multiply_plain(this->ciphertext, pt_diag, ct);
-        // TODO: relin and rescale
         this->context->evaluator->rotate_vector_inplace(
             ct, i, this->context->galois_keys());
         results.push_back(ct);
@@ -242,6 +241,7 @@ CKKSVector& CKKSVector::matmul_inplace(const vector<vector<double>>& matrix) {
 
     this->context->evaluator->add_many(results, this->ciphertext);
     this->_size = n_cols;
+    // TODO: relin and rescale
 
     return *this;
 }

--- a/tenseal/tensors/ckksvector.h
+++ b/tenseal/tensors/ckksvector.h
@@ -96,6 +96,7 @@ class CKKSVector {
 
         Ciphertext ciphertext(context->seal_context());
         Plaintext plaintext;
+        // TODO: get rid of this after fixing # 46
         if (pt.size() != 0) replicate_vector(pt, encoder.slot_count());
         encoder.encode(pt, scale, plaintext);
         context->encryptor->encrypt(plaintext, ciphertext);

--- a/tenseal/tensors/ckksvector.h
+++ b/tenseal/tensors/ckksvector.h
@@ -72,8 +72,8 @@ class CKKSVector {
     /*
     Matrix multiplication operations.
     */
-    CKKSVector matmul(const vector<vector<double>> matrix);
-    CKKSVector& matmul_inplace(const vector<vector<double>> matrix);
+    CKKSVector matmul(const vector<vector<double>>& matrix);
+    CKKSVector& matmul_inplace(const vector<vector<double>>& matrix);
 
    private:
     size_t _size;

--- a/tenseal/tensors/ckksvector.h
+++ b/tenseal/tensors/ckksvector.h
@@ -72,8 +72,8 @@ class CKKSVector {
     /*
     Matrix multiplication operations.
     */
-    CKKSVector matmul(const vector<vector<double>>& matrix);
-    CKKSVector& matmul_inplace(const vector<vector<double>>& matrix);
+    CKKSVector matmul_plain(const vector<vector<double>>& matrix);
+    CKKSVector& matmul_plain_inplace(const vector<vector<double>>& matrix);
 
    private:
     size_t _size;

--- a/tenseal/tensors/ckksvector.h
+++ b/tenseal/tensors/ckksvector.h
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "../tensealcontext.h"
+#include "../utils.h"
 
 using namespace seal;
 using namespace std;
@@ -68,6 +69,11 @@ class CKKSVector {
     CKKSVector mul_plain(vector<double> to_mul);
     CKKSVector& mul_plain_inplace(vector<double> to_mul);
 
+    /*
+    Matrix multiplication operations.
+    */
+    CKKSVector matmul_right(const vector<vector<double>> matrix);
+
    private:
     size_t _size;
 
@@ -89,6 +95,7 @@ class CKKSVector {
 
         Ciphertext ciphertext(context->seal_context());
         Plaintext plaintext;
+        if (pt.size() != 0) replicate_vector(pt, encoder.slot_count());
         encoder.encode(pt, scale, plaintext);
         context->encryptor->encrypt(plaintext, ciphertext);
 

--- a/tenseal/tensors/ckksvector.h
+++ b/tenseal/tensors/ckksvector.h
@@ -72,7 +72,8 @@ class CKKSVector {
     /*
     Matrix multiplication operations.
     */
-    CKKSVector matmul_right(const vector<vector<double>> matrix);
+    CKKSVector matmul(const vector<vector<double>> matrix);
+    CKKSVector& matmul_inplace(const vector<vector<double>> matrix);
 
    private:
     size_t _size;

--- a/tenseal/utils.h
+++ b/tenseal/utils.h
@@ -1,5 +1,5 @@
 #ifndef TENSEAL_UTILS_H
-#define TESNEAL_UTILS_H
+#define TENSEAL_UTILS_H
 
 #include <seal/seal.h>
 
@@ -32,6 +32,47 @@ Returns a smart pointer to a SEALContext created with the provided encryption
 parameters.
 */
 shared_ptr<seal::SEALContext> create_context(EncryptionParameters parms);
+
+/*
+Replicate the current vector as many times to fill `final_size` elements.
+*/
+template <typename T>
+void replicate_vector(vector<T>& vec, size_t final_size) {
+    size_t init_size = vec.size();
+    vec.reserve(final_size);
+    for (size_t i = 0; i < final_size - init_size; i++) {
+        vec.push_back(vec[i % init_size]);
+    }
+}
+
+/*
+Returns the k-th diagonal of a matrix. Positive values of k represent upper
+diagonals while negative values represent lower diagonal with 0 being the main
+diagonal. It's important to note that diagonals here are of the size of the
+matrix, we rotate as we reach the boundaries of the matrix.
+*/
+template <typename T>
+vector<T> get_diagonal(const vector<vector<T>> matrix, int k) {
+    size_t n_rows = matrix.size();
+    size_t n_cols = matrix[0].size();
+
+    vector<double> t_diag;
+    t_diag.reserve(n_rows * n_cols);
+
+    size_t r_offset = 0, c_offset = 0;
+    if (k > 0) {  // upper diagonals
+        c_offset = k;
+    } else {  // lower diagonal
+        r_offset = -k;
+    }
+
+    for (size_t i = 0; i < n_rows * n_cols; i++) {
+        t_diag.push_back(
+            matrix[(r_offset + i) % n_rows][(c_offset + i) % n_cols]);
+    }
+
+    return t_diag;
+}
 
 }  // namespace tenseal
 

--- a/tenseal/utils.h
+++ b/tenseal/utils.h
@@ -52,7 +52,7 @@ diagonal. It's important to note that diagonals here are of the size of the
 matrix, we rotate as we reach the boundaries of the matrix.
 */
 template <typename T>
-vector<T> get_diagonal(const vector<vector<T>> matrix, int k) {
+vector<T> get_diagonal(const vector<vector<T>>& matrix, int k) {
     size_t n_rows = matrix.size();
     size_t n_cols = matrix[0].size();
 

--- a/tenseal/utils.h
+++ b/tenseal/utils.h
@@ -38,6 +38,9 @@ Replicate the current vector as many times to fill `final_size` elements.
 */
 template <typename T>
 void replicate_vector(vector<T>& vec, size_t final_size) {
+    if (vec.empty()) {
+        throw invalid_argument("can't replicate an empty vector");
+    }
     size_t init_size = vec.size();
     vec.reserve(final_size);
     for (size_t i = 0; i < final_size - init_size; i++) {

--- a/tenseal/utils.h
+++ b/tenseal/utils.h
@@ -48,35 +48,6 @@ void replicate_vector(vector<T>& vec, size_t final_size) {
     }
 }
 
-/*
-Returns the k-th diagonal of a matrix. Positive values of k represent upper
-diagonals while negative values represent lower diagonal with 0 being the main
-diagonal. It's important to note that diagonals here are of the size of the
-matrix, we rotate as we reach the boundaries of the matrix.
-*/
-template <typename T>
-vector<T> get_diagonal(const vector<vector<T>>& matrix, int k) {
-    size_t n_rows = matrix.size();
-    size_t n_cols = matrix[0].size();
-
-    vector<double> t_diag;
-    t_diag.reserve(n_rows * n_cols);
-
-    size_t r_offset = 0, c_offset = 0;
-    if (k > 0) {  // upper diagonals
-        c_offset = k;
-    } else {  // lower diagonal
-        r_offset = -k;
-    }
-
-    for (size_t i = 0; i < n_rows * n_cols; i++) {
-        t_diag.push_back(
-            matrix[(r_offset + i) % n_rows][(c_offset + i) % n_cols]);
-    }
-
-    return t_diag;
-}
-
 }  // namespace tenseal
 
 #endif

--- a/tests/tensors/test_ckks_vector.py
+++ b/tests/tensors/test_ckks_vector.py
@@ -377,7 +377,28 @@ def test_vec_plain_matrix_mul(context, scale, vec, matrix):
     ct = ts.ckks_vector(context, scale, vec)
     result = ct.mm(matrix)
     expected = (np.array(vec) @ np.array(matrix)).tolist()
-    assert _almost_equal(result.decrypt(), expected, 1)
+    assert _almost_equal(result.decrypt(), expected, 1), "Matrix multiplciation is incorrect."
+
+
+@pytest.mark.parametrize(
+    "vec, matrix",
+    [
+        ([1, 2, 3], [[1, 2, 3], [1, 2, 3], [1, 2, 3]]),
+        ([0.7968, 0.7027, -0.5913], [[-0.0673, 0.2271], [-0.1252, 0.0273], [0.1905, -0.1435]]),
+        (
+            [0.2232, -2.0231],
+            [[1.5545, -0.8035, -0.5180, -0.0950], [0.2614, 0.7102, 0.2147, -0.6553]],
+        ),
+    ],
+)
+def test_vec_plain_matrix_mul_inplace(context, scale, vec, matrix):
+    import numpy as np
+
+    context.generate_galois_keys()
+    ct = ts.ckks_vector(context, scale, vec)
+    ct.mm_(matrix)
+    expected = (np.array(vec) @ np.array(matrix)).tolist()
+    assert _almost_equal(ct.decrypt(), expected, 1), "Matrix multiplciation is incorrect."
 
 
 def test_size(context, scale):

--- a/tests/tensors/test_ckks_vector.py
+++ b/tests/tensors/test_ckks_vector.py
@@ -378,6 +378,7 @@ def test_vec_plain_matrix_mul(context, scale, vec, matrix):
     result = ct.mm(matrix)
     expected = (np.array(vec) @ np.array(matrix)).tolist()
     assert _almost_equal(result.decrypt(), expected, 1), "Matrix multiplciation is incorrect."
+    assert _almost_equal(ct.decrypt(), vec, 1), "Something went wrong in memory."
 
 
 @pytest.mark.parametrize(

--- a/tests/tensors/test_ckks_vector.py
+++ b/tests/tensors/test_ckks_vector.py
@@ -359,6 +359,21 @@ def test_mul_plain_zero(context, scale):
     assert str(e.value) == "result ciphertext is transparent"
 
 
+@pytest.mark.parametrize(
+    "vec, matrix",
+    [
+        ([1, 2, 3], [[1, 2, 3], [1, 2, 3], [1, 2, 3]]),
+    ],
+)
+def test_vec_plain_matrix_mul(context, scale, vec, matrix):
+    import numpy as np
+    context.generate_galois_keys()
+    ct = ts.ckks_vector(context, scale, vec)
+    result = ct.matmul(matrix)
+    expected = (np.array(vec) @ np.array(matrix)).tolist()
+    assert _almost_equal(result.decrypt(), expected, 1)
+
+
 def test_size(context, scale):
     for size in range(10):
         vec = ts.ckks_vector(context, scale, [1] * size)

--- a/tests/tensors/test_ckks_vector.py
+++ b/tests/tensors/test_ckks_vector.py
@@ -363,13 +363,19 @@ def test_mul_plain_zero(context, scale):
     "vec, matrix",
     [
         ([1, 2, 3], [[1, 2, 3], [1, 2, 3], [1, 2, 3]]),
+        ([0.7968, 0.7027, -0.5913], [[-0.0673, 0.2271], [-0.1252, 0.0273], [0.1905, -0.1435]]),
+        (
+            [0.2232, -2.0231],
+            [[1.5545, -0.8035, -0.5180, -0.0950], [0.2614, 0.7102, 0.2147, -0.6553]],
+        ),
     ],
 )
 def test_vec_plain_matrix_mul(context, scale, vec, matrix):
     import numpy as np
+
     context.generate_galois_keys()
     ct = ts.ckks_vector(context, scale, vec)
-    result = ct.matmul(matrix)
+    result = ct.mm(matrix)
     expected = (np.array(vec) @ np.array(matrix)).tolist()
     assert _almost_equal(result.decrypt(), expected, 1)
 


### PR DESCRIPTION
This PR introduces utility to perform a variant of the diagonal method of [Halevi and Shoup](https://link.springer.com/content/pdf/10.1007%2F978-3-662-44371-2_31.pdf) and implements it for the CKKSVector.

## API changes
matrix is a plain matrix (list of list) and vector is plain vector (list)
```python
ct = ts.ckks_vector(context, scale, vec)
# following calls are equivalent
result = ct.mm(matrix)
result = ct.matmul(matrix)
result = ct @ matrix

# inplace functions
ct.mm_(matrix)
ct.matmul_(matrix)
ct @= matrix
```