### PR TITLE
Setting global_scale in TenSEALContext

### DIFF
--- a/tenseal/binding.cpp
+++ b/tenseal/binding.cpp
@@ -74,7 +74,10 @@ PYBIND11_MODULE(_tenseal_cpp, m) {
         .def("__imul__", &BFVVector::mul_plain_inplace);
 
     py::class_<CKKSVector>(m, "CKKSVector")
-        .def(py::init<shared_ptr<TenSEALContext>&, double, vector<double>>())
+        // specifying scale
+        .def(py::init<shared_ptr<TenSEALContext>&, vector<double>, double>())
+        // using global_scale if set
+        .def(py::init<shared_ptr<TenSEALContext>&, vector<double>>())
         .def("size", &CKKSVector::size)
         .def("decrypt", py::overload_cast<>(&CKKSVector::decrypt))
         .def("decrypt", py::overload_cast<SecretKey>(&CKKSVector::decrypt))

--- a/tenseal/binding.cpp
+++ b/tenseal/binding.cpp
@@ -113,6 +113,8 @@ PYBIND11_MODULE(_tenseal_cpp, m) {
 
     py::class_<TenSEALContext, std::shared_ptr<TenSEALContext>>(
         m, "TenSEALContext")
+        .def_property("global_scale", &TenSEALContext::global_scale,
+                      &TenSEALContext::set_global_scale)
         .def("new",
              py::overload_cast<scheme_type, size_t, uint64_t, vector<int>>(
                  &TenSEALContext::Create),

--- a/tenseal/tensealcontext.h
+++ b/tenseal/tensealcontext.h
@@ -193,6 +193,13 @@ class TenSEALContext {
         encoder->encode(vec, scale, pt);
     }
 
+    // TODO: check set scale if possible with current primes used and warn the
+    // user if it doesn't.
+    // Example: if using coeff_mod_bit_size of [60,40,40,60],
+    // the global scale should be set for 2**40
+    void set_global_scale(double scale) { this->_scale = scale; }
+    double global_scale() { return this->_scale; }
+
    private:
     EncryptionParameters _parms;
     shared_ptr<SEALContext> _context;
@@ -201,6 +208,11 @@ class TenSEALContext {
     shared_ptr<RelinKeys> _relin_keys;
     shared_ptr<GaloisKeys> _galois_keys;
     shared_ptr<TenSEALEncoder> encoder_factory;
+
+    /*
+    Stores a global scale used across ciphertext encrypted using CKKS.
+    */
+    double _scale = -1;
 
     TenSEALContext(EncryptionParameters parms);
     TenSEALContext(const char* filename);

--- a/tenseal/tensors/__init__.py
+++ b/tenseal/tensors/__init__.py
@@ -22,21 +22,23 @@ def bfv_vector(context, plaintext_vector):
     return _ts_cpp.BFVVector(context, plaintext_vector)
 
 
-def ckks_vector(context, scale, plaintext_vector):
+def ckks_vector(context, plaintext_vector, scale=None):
     """Constructor method for the CKKSVector object, which can store a list
     of float numbers in encrypted form, using the CKKS homomorphic encryption
     scheme.
 
     Args:
         context: a TenSEALContext object, holding the encryption parameters and keys.
-        scale: the scale to be used to encode vector values.
         plaintext_vector: a list of float to be encrypted.
+        scale: the scale to be used to encode vector values.
+            CKKSVector will use the global_scale provided by the context if it's set to None.
 
     Returns:
         CKKSVector object.
     """
-
-    return _ts_cpp.CKKSVector(context, scale, plaintext_vector)
+    if scale is None:
+        return _ts_cpp.CKKSVector(context, plaintext_vector)
+    return _ts_cpp.CKKSVector(context, plaintext_vector, scale)
 
 
 __all__ = ["bfv_vector", "ckks_vector"]

--- a/tenseal/tensors/ckksvector.cpp
+++ b/tenseal/tensors/ckksvector.cpp
@@ -14,9 +14,17 @@ using namespace std;
 
 namespace tenseal {
 
-CKKSVector::CKKSVector(shared_ptr<TenSEALContext> context, double scale,
-                       vector<double> vec) {
+CKKSVector::CKKSVector(shared_ptr<TenSEALContext> context, vector<double> vec,
+                       double scale) {
     this->context = context;
+    if (scale == -1) {
+        if (context->global_scale() == -1) {
+            throw invalid_argument(
+                "you need to either provide a scale or set a global_scale in "
+                "the context");
+        }
+        scale = context->global_scale();
+    }
     this->init_scale = scale;
     // Encrypts the whole vector into a single ciphertext using CKKS batching
     this->ciphertext = CKKSVector::encrypt(context, scale, vec);

--- a/tenseal/tensors/ckksvector.h
+++ b/tenseal/tensors/ckksvector.h
@@ -20,8 +20,8 @@ encryption scheme.
 */
 class CKKSVector {
    public:
-    CKKSVector(shared_ptr<TenSEALContext> context, double scale,
-               vector<double> vec);
+    CKKSVector(shared_ptr<TenSEALContext> context, vector<double> vec,
+               double scale = -1);
 
     CKKSVector(const CKKSVector& vec);
 

--- a/tests/tensors/test_ckks_vector.py
+++ b/tests/tensors/test_ckks_vector.py
@@ -15,12 +15,9 @@ def _almost_equal(vec1, vec2, m_pow_ten):
 
 @pytest.fixture(scope="module")
 def context():
-    return ts.context(ts.SCHEME_TYPE.CKKS, 8192, coeff_mod_bit_sizes=[60, 40, 40, 60])
-
-
-@pytest.fixture(scope="module")
-def scale():
-    return pow(2, 40)
+    context = ts.context(ts.SCHEME_TYPE.CKKS, 8192, coeff_mod_bit_sizes=[60, 40, 40, 60])
+    context.global_scale = pow(2, 40)
+    return context
 
 
 @pytest.mark.parametrize(
@@ -38,9 +35,9 @@ def scale():
         ([1, 2], [-73, -10]),
     ],
 )
-def test_add(context, scale, vec1, vec2):
-    first_vec = ts.ckks_vector(context, scale, vec1)
-    second_vec = ts.ckks_vector(context, scale, vec2)
+def test_add(context, vec1, vec2):
+    first_vec = ts.ckks_vector(context, vec1)
+    second_vec = ts.ckks_vector(context, vec2)
     result = first_vec + second_vec
     expected = [v1 + v2 for v1, v2 in zip(vec1, vec2)]
 
@@ -66,9 +63,9 @@ def test_add(context, scale, vec1, vec2):
         ([1, 2], [-73, -10]),
     ],
 )
-def test_add_inplace(context, scale, vec1, vec2):
-    first_vec = ts.ckks_vector(context, scale, vec1)
-    second_vec = ts.ckks_vector(context, scale, vec2)
+def test_add_inplace(context, vec1, vec2):
+    first_vec = ts.ckks_vector(context, vec1)
+    second_vec = ts.ckks_vector(context, vec2)
     first_vec += second_vec
     expected = [v1 + v2 for v1, v2 in zip(vec1, vec2)]
 
@@ -93,8 +90,8 @@ def test_add_inplace(context, scale, vec1, vec2):
         ([1, 2], [-73, -10]),
     ],
 )
-def test_add_plain(context, scale, vec1, vec2):
-    first_vec = ts.ckks_vector(context, scale, vec1)
+def test_add_plain(context, vec1, vec2):
+    first_vec = ts.ckks_vector(context, vec1)
     second_vec = vec2
     result = first_vec + second_vec
     expected = [v1 + v2 for v1, v2 in zip(vec1, vec2)]
@@ -120,8 +117,8 @@ def test_add_plain(context, scale, vec1, vec2):
         ([1, 2], [-73, -10]),
     ],
 )
-def test_add_plain_inplace(context, scale, vec1, vec2):
-    first_vec = ts.ckks_vector(context, scale, vec1)
+def test_add_plain_inplace(context, vec1, vec2):
+    first_vec = ts.ckks_vector(context, vec1)
     second_vec = vec2
     first_vec += second_vec
     expected = [v1 + v2 for v1, v2 in zip(vec1, vec2)]
@@ -146,9 +143,9 @@ def test_add_plain_inplace(context, scale, vec1, vec2):
         ([1, 2], [-73, -10]),
     ],
 )
-def test_sub(context, scale, vec1, vec2):
-    first_vec = ts.ckks_vector(context, scale, vec1)
-    second_vec = ts.ckks_vector(context, scale, vec2)
+def test_sub(context, vec1, vec2):
+    first_vec = ts.ckks_vector(context, vec1)
+    second_vec = ts.ckks_vector(context, vec2)
     result = first_vec - second_vec
     expected = [v1 - v2 for v1, v2 in zip(vec1, vec2)]
 
@@ -174,9 +171,9 @@ def test_sub(context, scale, vec1, vec2):
         ([1, 2], [-73, -10]),
     ],
 )
-def test_sub_inplace(context, scale, vec1, vec2):
-    first_vec = ts.ckks_vector(context, scale, vec1)
-    second_vec = ts.ckks_vector(context, scale, vec2)
+def test_sub_inplace(context, vec1, vec2):
+    first_vec = ts.ckks_vector(context, vec1)
+    second_vec = ts.ckks_vector(context, vec2)
     first_vec -= second_vec
     expected = [v1 - v2 for v1, v2 in zip(vec1, vec2)]
 
@@ -201,8 +198,8 @@ def test_sub_inplace(context, scale, vec1, vec2):
         ([1, 2], [-73, -10]),
     ],
 )
-def test_sub_plain(context, scale, vec1, vec2):
-    first_vec = ts.ckks_vector(context, scale, vec1)
+def test_sub_plain(context, vec1, vec2):
+    first_vec = ts.ckks_vector(context, vec1)
     second_vec = vec2
     result = first_vec - second_vec
     expected = [v1 - v2 for v1, v2 in zip(vec1, vec2)]
@@ -228,8 +225,8 @@ def test_sub_plain(context, scale, vec1, vec2):
         ([1, 2], [-73, -10]),
     ],
 )
-def test_sub_plain_inplace(context, scale, vec1, vec2):
-    first_vec = ts.ckks_vector(context, scale, vec1)
+def test_sub_plain_inplace(context, vec1, vec2):
+    first_vec = ts.ckks_vector(context, vec1)
     second_vec = vec2
     first_vec -= second_vec
     expected = [v1 - v2 for v1, v2 in zip(vec1, vec2)]
@@ -254,9 +251,9 @@ def test_sub_plain_inplace(context, scale, vec1, vec2):
         ([1, 2], [-73, -10]),
     ],
 )
-def test_mul(context, scale, vec1, vec2):
-    first_vec = ts.ckks_vector(context, scale, vec1)
-    second_vec = ts.ckks_vector(context, scale, vec2)
+def test_mul(context, vec1, vec2):
+    first_vec = ts.ckks_vector(context, vec1)
+    second_vec = ts.ckks_vector(context, vec2)
     result = first_vec * second_vec
     expected = [v1 * v2 for v1, v2 in zip(vec1, vec2)]
 
@@ -282,9 +279,9 @@ def test_mul(context, scale, vec1, vec2):
         ([1, 2], [-73, -10]),
     ],
 )
-def test_mul_inplace(context, scale, vec1, vec2):
-    first_vec = ts.ckks_vector(context, scale, vec1)
-    second_vec = ts.ckks_vector(context, scale, vec2)
+def test_mul_inplace(context, vec1, vec2):
+    first_vec = ts.ckks_vector(context, vec1)
+    second_vec = ts.ckks_vector(context, vec2)
     first_vec *= second_vec
     expected = [v1 * v2 for v1, v2 in zip(vec1, vec2)]
 
@@ -309,8 +306,8 @@ def test_mul_inplace(context, scale, vec1, vec2):
         ([1, 2], [-73, -10]),
     ],
 )
-def test_mul_plain(context, scale, vec1, vec2):
-    first_vec = ts.ckks_vector(context, scale, vec1)
+def test_mul_plain(context, vec1, vec2):
+    first_vec = ts.ckks_vector(context, vec1)
     second_vec = vec2
     result = first_vec * second_vec
     expected = [v1 * v2 for v1, v2 in zip(vec1, vec2)]
@@ -336,8 +333,8 @@ def test_mul_plain(context, scale, vec1, vec2):
         ([1, 2], [-73, -10]),
     ],
 )
-def test_mul_plain_inplace(context, scale, vec1, vec2):
-    first_vec = ts.ckks_vector(context, scale, vec1)
+def test_mul_plain_inplace(context, vec1, vec2):
+    first_vec = ts.ckks_vector(context, vec1)
     second_vec = vec2
     first_vec *= second_vec
     expected = [v1 * v2 for v1, v2 in zip(vec1, vec2)]
@@ -347,11 +344,11 @@ def test_mul_plain_inplace(context, scale, vec1, vec2):
     assert _almost_equal(decrypted_result, expected, 1), "Multiplication of vectors is incorrect."
 
 
-def test_mul_plain_zero(context, scale):
+def test_mul_plain_zero(context):
     # from context
     max_slots = 8192 // 2
     pt = [0] * max_slots
-    ct = ts.ckks_vector(context, scale, [1] * max_slots)
+    ct = ts.ckks_vector(context, [1] * max_slots)
 
     with pytest.raises(RuntimeError) as e:
         # the workaround of transparent ciphertext doesn't work when all slots are used
@@ -370,11 +367,11 @@ def test_mul_plain_zero(context, scale):
         ),
     ],
 )
-def test_vec_plain_matrix_mul(context, scale, vec, matrix):
+def test_vec_plain_matrix_mul(context, vec, matrix):
     import numpy as np
 
     context.generate_galois_keys()
-    ct = ts.ckks_vector(context, scale, vec)
+    ct = ts.ckks_vector(context, vec)
     result = ct.mm(matrix)
     expected = (np.array(vec) @ np.array(matrix)).tolist()
     assert _almost_equal(result.decrypt(), expected, 1), "Matrix multiplciation is incorrect."
@@ -392,17 +389,17 @@ def test_vec_plain_matrix_mul(context, scale, vec, matrix):
         ),
     ],
 )
-def test_vec_plain_matrix_mul_inplace(context, scale, vec, matrix):
+def test_vec_plain_matrix_mul_inplace(context, vec, matrix):
     import numpy as np
 
     context.generate_galois_keys()
-    ct = ts.ckks_vector(context, scale, vec)
+    ct = ts.ckks_vector(context, vec)
     ct.mm_(matrix)
     expected = (np.array(vec) @ np.array(matrix)).tolist()
     assert _almost_equal(ct.decrypt(), expected, 1), "Matrix multiplciation is incorrect."
 
 
-def test_size(context, scale):
+def test_size(context):
     for size in range(10):
-        vec = ts.ckks_vector(context, scale, [1] * size)
+        vec = ts.ckks_vector(context, [1] * size)
         assert vec.size() == size, "Size of encrypted vector is incorrect."

--- a/tests/tensors/test_ckks_vector.py
+++ b/tests/tensors/test_ckks_vector.py
@@ -368,7 +368,7 @@ def test_mul_plain_zero(context):
         ),
     ],
 )
-def test_vec_plain_matrix_mul(context, scale, vec, matrix):
+def test_vec_plain_matrix_mul(context, vec, matrix):
     context.generate_galois_keys()
     ct = ts.ckks_vector(context, vec)
     result = ct.mm(matrix)
@@ -388,7 +388,7 @@ def test_vec_plain_matrix_mul(context, scale, vec, matrix):
         ),
     ],
 )
-def test_vec_plain_matrix_mul_inplace(context, scale, vec, matrix):
+def test_vec_plain_matrix_mul_inplace(context, vec, matrix):
     context.generate_galois_keys()
     ct = ts.ckks_vector(context, vec)
     ct.mm_(matrix)
@@ -417,15 +417,15 @@ def test_vec_plain_matrix_mul_inplace(context, scale, vec, matrix):
         ),
     ],
 )
-def test_vec_plain_matrix_mul_depth2(context, scale, vec, matrix1, matrix2):
+def test_vec_plain_matrix_mul_depth2(context, vec, matrix1, matrix2):
     context.generate_galois_keys()
-    ct = ts.ckks_vector(context, scale, vec)
+    ct = ts.ckks_vector(context, vec)
     result = ct @ matrix1 @ matrix2
     expected = (np.array(vec) @ np.array(matrix1) @ np.array(matrix2)).tolist()
     assert _almost_equal(result.decrypt(), expected, 1), "Matrix multiplication is incorrect."
 
 
-def test_size(context, scale):
+def test_size(context):
     for size in range(10):
         vec = ts.ckks_vector(context, [1] * size)
         assert vec.size() == size, "Size of encrypted vector is incorrect."

--- a/tests/tensors/test_perf.py
+++ b/tests/tensors/test_perf.py
@@ -16,7 +16,7 @@ def ckks_test():
     ctx = ts.context(ts.SCHEME_TYPE.CKKS, 8192, coeff_mod_bit_sizes=[60, 40, 40, 60])
     l, r = gen_values(200)
     scale = 2 ** 40
-    return ts.ckks_vector(ctx, scale, l), ts.ckks_vector(ctx, scale, r)
+    return ts.ckks_vector(ctx, l, scale), ts.ckks_vector(ctx, r, scale)
 
 
 def helper_perf_add(generator):

--- a/tests/test_enc_dec.py
+++ b/tests/test_enc_dec.py
@@ -40,7 +40,17 @@ def test_ckks_encryption_decryption(plain_vec):
     context = ts.context(ts.SCHEME_TYPE.CKKS, 8192, coeff_mod_bit_sizes=[60, 40, 40, 60])
     scale = pow(2, 40)
 
-    ckks_vec = ts.ckks_vector(context, scale, plain_vec)
+    ckks_vec = ts.ckks_vector(context, plain_vec, scale)
+    decrypted_vec = ckks_vec.decrypt()
+    assert _almost_equal(decrypted_vec, plain_vec, 1), "Decryption of vector is incorrect"
+
+
+@pytest.mark.parametrize("plain_vec", [[], [0], [-1], [1], [73, 81, 90], [-73, -81, -90],])
+def test_ckks_encryption_decryption_with_global_scale(plain_vec):
+    context = ts.context(ts.SCHEME_TYPE.CKKS, 8192, coeff_mod_bit_sizes=[60, 40, 40, 60])
+    context.global_scale = pow(2, 40)
+
+    ckks_vec = ts.ckks_vector(context, plain_vec)
     decrypted_vec = ckks_vec.decrypt()
     assert _almost_equal(decrypted_vec, plain_vec, 1), "Decryption of vector is incorrect"
 
@@ -50,7 +60,7 @@ def test_ckks_secretkey_decryption(plain_vec):
     context = ts.context(ts.SCHEME_TYPE.CKKS, 8192, coeff_mod_bit_sizes=[60, 40, 40, 60])
     scale = pow(2, 40)
 
-    ckks_vec = ts.ckks_vector(context, scale, plain_vec)
+    ckks_vec = ts.ckks_vector(context, plain_vec, scale)
     secret_key = context.secret_key()
     context.make_context_public()
     decrypted_vec = ckks_vec.decrypt(secret_key)

--- a/tests/test_tensealcontext.py
+++ b/tests/test_tensealcontext.py
@@ -30,3 +30,12 @@ def test_generate_relin_keys():
 
     context.generate_relin_keys(secret_key)
     assert isinstance(context.relin_keys(), ts.RelinKeys), "Relin keys should be set"
+
+
+def test_global_scale():
+    context = ts.context(ts.SCHEME_TYPE.CKKS, 8192, 0, [60, 40, 40, 60])
+    # global scale shouldn't be set at first
+    assert context.global_scale == -1
+    for scale in [0, 1, 2, 2**40]:
+        context.global_scale = scale
+        assert context.global_scale == scale

--- a/tests/test_tensealcontext.py
+++ b/tests/test_tensealcontext.py
@@ -36,6 +36,6 @@ def test_global_scale():
     context = ts.context(ts.SCHEME_TYPE.CKKS, 8192, 0, [60, 40, 40, 60])
     # global scale shouldn't be set at first
     assert context.global_scale == -1
-    for scale in [0, 1, 2, 2**40]:
+    for scale in [0, 1, 2, 2 ** 40]:
         context.global_scale = scale
         assert context.global_scale == scale


### PR DESCRIPTION
As per the discussion in #38 , this PR introduce some first changes towards using a global scale.

- Introduces the global_scale attribute for TenSEALContext which will hold the default scale that should be used if the user doesn't specify one while creating a CKKSVector.
- As stated above, CKKSVector now can be created without specifying a scale when the TenSEALContext have been set with a global_scale.

### API Changes

Now we should use either of those to create a CKKSVector

```python
# first option: specifying a scale
vector = tenseal.ckks_vector(context, [1, 2, 3], scale=2 ** 20)

# second option: use the global_scale after first setting it in the context
context.global_scale = 2 ** 20
vector = tenseal.ckks_vector(context, [1, 2, 3])

