### PR TITLE
Add summation aggregation with dot product

### DIFF
--- a/tenseal/binding.cpp
+++ b/tenseal/binding.cpp
@@ -100,6 +100,8 @@ PYBIND11_MODULE(_tenseal_cpp, m) {
         .def("dot", &CKKSVector::dot_product_plain)
         .def("dot_", &CKKSVector::dot_product_inplace)
         .def("dot_", &CKKSVector::dot_product_plain_inplace)
+        .def("sum", &CKKSVector::sum)
+        .def("sum_", &CKKSVector::sum_inplace)
         .def("matmul", &CKKSVector::matmul_plain)
         .def("matmul_", &CKKSVector::matmul_plain_inplace)
         .def("mm", &CKKSVector::matmul_plain)

--- a/tenseal/tensors/ckksvector.cpp
+++ b/tenseal/tensors/ckksvector.cpp
@@ -272,6 +272,18 @@ CKKSVector& CKKSVector::dot_product_plain_inplace(vector<double> to_mul) {
     return *this;
 }
 
+CKKSVector CKKSVector::sum() {
+    CKKSVector new_vector = *this;
+    new_vector.sum_inplace();
+    return new_vector;
+}
+
+CKKSVector& CKKSVector::sum_inplace() {
+    sum_vector(this->context, this->ciphertext, this->size());
+    this->_size = 1;
+    return *this;
+}
+
 CKKSVector CKKSVector::matmul_plain(const vector<vector<double>>& matrix) {
     CKKSVector new_vector = *this;
     return new_vector.matmul_plain_inplace(matrix);

--- a/tenseal/tensors/ckksvector.h
+++ b/tenseal/tensors/ckksvector.h
@@ -72,6 +72,15 @@ class CKKSVector {
     CKKSVector& mul_plain_inplace(vector<double> to_mul);
     CKKSVector dot_product_plain(vector<double> to_mul);
     CKKSVector& dot_product_plain_inplace(vector<double> to_mul);
+    
+    /*
+    Encrypted aggregation functions operates on a single encrypted vector 
+    (itself) and returns a new CKKSVector which is the result of its 
+    aggregation. (Currently only summation is implemented). in_place 
+    functions return a reference to the same object
+    */
+    CKKSVector sum();
+    CKKSVector& sum_inplace();
 
     /*
     Matrix multiplication operations.

--- a/tenseal/tensors/ckksvector.h
+++ b/tenseal/tensors/ckksvector.h
@@ -74,10 +74,7 @@ class CKKSVector {
     CKKSVector& dot_product_plain_inplace(vector<double> to_mul);
     
     /*
-    Encrypted aggregation functions operates on a single encrypted vector 
-    (itself) and returns a new CKKSVector which is the result of its 
-    aggregation. (Currently only summation is implemented). in_place 
-    functions return a reference to the same object
+    Encrypted aggregation functions operates on a single encrypted vector.
     */
     CKKSVector sum();
     CKKSVector& sum_inplace();

--- a/tenseal/tensors/ckksvector.h
+++ b/tenseal/tensors/ckksvector.h
@@ -72,10 +72,6 @@ class CKKSVector {
     CKKSVector& mul_plain_inplace(vector<double> to_mul);
     CKKSVector dot_product_plain(vector<double> to_mul);
     CKKSVector& dot_product_plain_inplace(vector<double> to_mul);
-    
-    /*
-    Encrypted aggregation functions operates on a single encrypted vector.
-    */
     CKKSVector sum();
     CKKSVector& sum_inplace();
 

--- a/tests/tensors/test_ckks_vector.py
+++ b/tests/tensors/test_ckks_vector.py
@@ -473,7 +473,7 @@ def test_sum(context, vec1):
     context.generate_galois_keys()
     first_vec = ts.ckks_vector(context, vec1)
     result = first_vec.sum()
-    expected = [sum(vec1])]
+    expected = [sum(vec1)]
 
     # Decryption
     decrypted_result = result.decrypt()
@@ -497,7 +497,7 @@ def test_sum_inplace(context, vec1):
     context.generate_galois_keys()
     first_vec = ts.ckks_vector(context, vec1)
     result = first_vec.sum()
-    expected = [sum(vec1])]
+    expected = [sum(vec1)]
 
     # Decryption
     decrypted_result = result.decrypt()

--- a/tests/tensors/test_ckks_vector.py
+++ b/tests/tensors/test_ckks_vector.py
@@ -457,6 +457,53 @@ def test_dot_product_plain_inplace(context, vec1, vec2):
     assert _almost_equal(decrypted_result, expected, 1), "Dot product of vectors is incorrect."
 
 
+@pytest.mark.parametrize(
+    "vec1",
+    [
+        ([]),
+        ([0]),
+        ([-1, 1]),
+        ([-1, 0, 1]),
+        ([1, 2, 3, 4]),
+        ([-1, -2, -73, -10]),
+        ([1, 2, -73, -10]),
+    ],
+)
+def test_sum(context, vec1):
+    context.generate_galois_keys()
+    first_vec = ts.ckks_vector(context, vec1)
+    result = first_vec.sum()
+    expected = [sum(vec1])]
+
+    # Decryption
+    decrypted_result = result.decrypt()
+    assert _almost_equal(decrypted_result, expected, 1), "Sum of vector is incorrect."
+    assert _almost_equal(first_vec.decrypt(), vec1, 1), "Something went wrong in memory."
+
+
+@pytest.mark.parametrize(
+    "vec1",
+    [
+        ([]),
+        ([0]),
+        ([-1, 1]),
+        ([-1, 0, 1]),
+        ([1, 2, 3, 4]),
+        ([-1, -2, -73, -10]),
+        ([1, 2, -73, -10]),
+    ],
+)
+def test_sum_inplace(context, vec1):
+    context.generate_galois_keys()
+    first_vec = ts.ckks_vector(context, vec1)
+    result = first_vec.sum()
+    expected = [sum(vec1])]
+
+    # Decryption
+    decrypted_result = result.decrypt()
+    assert _almost_equal(decrypted_result, expected, 1), "Sum of vector is incorrect."
+
+
 def test_mul_plain_zero(context):
     # from context
     max_slots = 8192 // 2


### PR DESCRIPTION
## Description
Exposed the sum_vector operation to the python api. This is so that a more efficient summation can be performed (rather than perform a dot product on a plain identity vector). This introduces a new class of operations of CKKS vectors that only operate on one operand and return a vector of size one (aggregations). In the future other aggregations could be implemented (such as multiplications for a geometric mean).

## Affected Dependencies
No dependencies are required to change.

## How has this been tested?
I built the Dockerfile-py36 and ran the tests in interactive mode.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
