### PR TITLE
Fix out-of-line declaration in tensealcontext

### DIFF
--- a/tenseal/tensealcontext.cpp
+++ b/tenseal/tensealcontext.cpp
@@ -150,9 +150,6 @@ void TenSEALContext::make_context_public(bool generate_galois_keys,
 bool TenSEALContext::is_public() { return this->_secret_key == nullptr; }
 bool TenSEALContext::is_private() { return !is_public(); }
 
-void TenSEALContext::save_public(const char* filename);
-void TenSEALContext::save_private(const char* filename);
-
 shared_ptr<SEALContext> TenSEALContext::seal_context() { return _context; }
 
 void TenSEALContext::global_scale(double scale) {


### PR DESCRIPTION
MacOS build was crashing because of a redefinition of those two function in the .cpp file

```bash
[ 76%] Building CXX object CMakeFiles/_sealapi_cpp.dir/tenseal/sealapi/sealapi.cpp.o
  /private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/pip-req-build-bnl6xxxa/tenseal/tensealcontext.cpp:153:22: error: out-of-line declaration of a member must be a definition [-Wout-of-line-declaration]
  void TenSEALContext::save_public(const char* filename);
       ~~~~~~~~~~~~~~~~^
  /private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/pip-req-build-bnl6xxxa/tenseal/tensealcontext.cpp:154:22: error: out-of-line declaration of a member must be a definition [-Wout-of-line-declaration]
  void TenSEALContext::save_private(const char* filename);
       ~~~~~~~~~~~~~~~~^
  2 errors generated.
```