### PR TITLE
add missing header include for "optional"

### DIFF
--- a/tenseal/tensealencoder.h
+++ b/tenseal/tensealencoder.h
@@ -5,9 +5,9 @@
 
 #include <any>
 #include <map>
+#include <optional>
 #include <typeindex>
 #include <vector>
-#include <optional>
 
 namespace tenseal {
 

--- a/tenseal/tensealencoder.h
+++ b/tenseal/tensealencoder.h
@@ -7,6 +7,7 @@
 #include <map>
 #include <typeindex>
 #include <vector>
+#include <optional>
 
 namespace tenseal {
 

--- a/tenseal/tensors/ckksvector.cpp
+++ b/tenseal/tensors/ckksvector.cpp
@@ -3,8 +3,8 @@
 #include <seal/seal.h>
 
 #include <memory>
-#include <vector>
 #include <optional>
+#include <vector>
 
 #include "tenseal/tensealcontext.h"
 #include "tenseal/utils/matrix_ops.h"

--- a/tenseal/tensors/ckksvector.cpp
+++ b/tenseal/tensors/ckksvector.cpp
@@ -4,6 +4,7 @@
 
 #include <memory>
 #include <vector>
+#include <optional>
 
 #include "tenseal/tensealcontext.h"
 #include "tenseal/utils/matrix_ops.h"

--- a/tenseal/tensors/ckksvector.h
+++ b/tenseal/tensors/ckksvector.h
@@ -5,6 +5,7 @@
 
 #include <memory>
 #include <vector>
+#include <optional>
 
 #include "tenseal/tensealcontext.h"
 #include "tenseal/utils/utils.h"

--- a/tenseal/tensors/ckksvector.h
+++ b/tenseal/tensors/ckksvector.h
@@ -4,8 +4,8 @@
 #include <seal/seal.h>
 
 #include <memory>
-#include <vector>
 #include <optional>
+#include <vector>
 
 #include "tenseal/tensealcontext.h"
 #include "tenseal/utils/utils.h"


### PR DESCRIPTION
Windows Build was crashing because of a missing include for "optional" header.
Visual Studio 2019 requires "optional" to be included in order to use std::optional.