### PR TITLE
Catch transparent ct and replace with encrypted zero

### DIFF
--- a/tenseal/tensors/bfvvector.cpp
+++ b/tenseal/tensors/bfvvector.cpp
@@ -190,16 +190,16 @@ BFVVector& BFVVector::mul_plain_inplace(const vector<int64_t>& to_mul) {
         throw invalid_argument("can't multiply vectors of different sizes");
     }
 
-    // TODO: rmeove this after fixing #36
-    // prevent transparent ciphertext by adding a non-zero value
     Plaintext plaintext;
-    vector<int64_t> new_vec_to_mul(to_mul);
-    if (new_vec_to_mul.size() + 1 <= this->context->slot_count<BatchEncoder>())
-        new_vec_to_mul.push_back(1);
-    this->context->encode<BatchEncoder>(new_vec_to_mul, plaintext);
+    this->context->encode<BatchEncoder>(to_mul, plaintext);
 
-    this->context->evaluator->multiply_plain_inplace(this->ciphertext,
-                                                     plaintext);
+    try {
+        this->context->evaluator->multiply_plain_inplace(this->ciphertext,
+                                                         plaintext);
+    } catch (const std::logic_error& e) {  // result ciphertext is transparent
+        // replace by encryption of zero
+        this->context->encryptor->encrypt_zero(this->ciphertext);
+    }
 
     return *this;
 }

--- a/tests/tensors/test_bvf_vector.py
+++ b/tests/tensors/test_bvf_vector.py
@@ -331,18 +331,6 @@ def test_mul_plain_inplace(context, vec1, vec2):
     assert decrypted_result == expected, "Multiplication of vectors is incorrect."
 
 
-def test_mul_plain_zero(context):
-    # from context
-    max_slots = 8192
-    pt = [0] * max_slots
-    ct = ts.bfv_vector(context, [1] * max_slots)
-
-    with pytest.raises(RuntimeError) as e:
-        # the workaround of transparent ciphertext doesn't work when all slots are used
-        result = ct * pt
-    assert str(e.value) == "result ciphertext is transparent"
-
-
 def test_size(context):
     for size in range(10):
         vec = ts.bfv_vector(context, [1] * size)

--- a/tests/tensors/test_ckks_vector.py
+++ b/tests/tensors/test_ckks_vector.py
@@ -482,7 +482,7 @@ def test_mul_inplace(context, vec1, vec2):
         ([-1, -2], [-73, -10]),
         ([1, 2], [-73, -10]),
         ([1, 2, 3, 4], 2),
-        # ([1, 2, 3, 4], 0),
+        ([1, 2, 3, 4], 0),
         ([1, 2, 3, 4], -2),
     ],
 )
@@ -515,7 +515,7 @@ def test_mul_plain(context, vec1, vec2):
         ([-1, -2], [-73, -10]),
         ([1, 2], [-73, -10]),
         ([1, 2, 3, 4], 2),
-        # ([1, 2, 3, 4], 0),
+        ([1, 2, 3, 4], 0),
         ([1, 2, 3, 4], -2),
     ],
 )
@@ -547,7 +547,7 @@ def test_rmul_plain(context, vec1, vec2):
         ([-1, -2], [-73, -10]),
         ([1, 2], [-73, -10]),
         ([1, 2, 3, 4], 2),
-        # ([1, 2, 3, 4], 0),
+        ([1, 2, 3, 4], 0),
         ([1, 2, 3, 4], -2),
     ],
 )
@@ -746,18 +746,6 @@ def test_sum_inplace(context, vec1):
     # Decryption
     decrypted_result = result.decrypt()
     assert _almost_equal(decrypted_result, expected, 1), "Sum of vector is incorrect."
-
-
-def test_mul_plain_zero(context):
-    # from context
-    max_slots = 8192 // 2
-    pt = [0] * max_slots
-    ct = ts.ckks_vector(context, [1] * max_slots)
-
-    with pytest.raises(RuntimeError) as e:
-        # the workaround of transparent ciphertext doesn't work when all slots are used
-        result = ct * pt
-    assert str(e.value) == "result ciphertext is transparent"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

When multiplying with a plain vector of all zeros, an exception is raised about the resulting ciphertext which is transparent. As discussed in #36, we now catch this exception and replace the resulting ct with an encryption of zero.

Fixes #36 

## How has this been tested?
- Automated tests

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
