### PR TITLE
Update docker images

### DIFF
--- a/docker-images/Dockerfile-py36
+++ b/docker-images/Dockerfile-py36
@@ -3,7 +3,7 @@ FROM python:3.6-slim-buster
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update
-RUN apt-get install -y git build-essential cmake
+RUN apt-get install -y git build-essential cmake libprotobuf-dev protobuf-compiler
 COPY ./ ./TenSEAL
 WORKDIR /TenSEAL
 # 3rd party libraries

--- a/docker-images/Dockerfile-py37
+++ b/docker-images/Dockerfile-py37
@@ -3,7 +3,7 @@ FROM python:3.7-slim-buster
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update
-RUN apt-get install -y git build-essential cmake
+RUN apt-get install -y git build-essential cmake libprotobuf-dev protobuf-compiler
 COPY ./ ./TenSEAL
 WORKDIR /TenSEAL
 # 3rd party libraries

--- a/docker-images/Dockerfile-py38
+++ b/docker-images/Dockerfile-py38
@@ -3,7 +3,7 @@ FROM python:3.8-slim-buster
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update
-RUN apt-get install -y git build-essential cmake
+RUN apt-get install -y git build-essential cmake libprotobuf-dev protobuf-compiler
 COPY ./ ./TenSEAL
 WORKDIR /TenSEAL
 # 3rd party libraries

--- a/tenseal/proto/CMakeLists.txt
+++ b/tenseal/proto/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
-
 include(FindProtobuf)
 find_package(Protobuf REQUIRED)
 set(Protobuf_USE_STATIC_LIBS YES)


### PR DESCRIPTION
## Description
-  Remove `cmake_minimum_required` from `tenseal_proto` cmake file.
- Update docker images and install new protobuf compiler.