### PR TITLE
Upgrade SEAL to 3.5.6

### DIFF
--- a/tenseal/sealapi/sealapi_context.cpp
+++ b/tenseal/sealapi/sealapi_context.cpp
@@ -138,7 +138,8 @@ void bind_context(pybind11::module &m) {
         .def("total_coeff_modulus_bit_count",
              &SEALContext::ContextData::total_coeff_modulus_bit_count)
         .def("coeff_div_plain_modulus",
-             &SEALContext::ContextData::coeff_div_plain_modulus)
+             &SEALContext::ContextData::coeff_div_plain_modulus,
+             py::return_value_policy::reference)
         .def("plain_upper_half_threshold",
              &SEALContext::ContextData::plain_upper_half_threshold)
         .def("upper_half_threshold",

--- a/tenseal/sealapi/sealapi_util_namespace.cpp
+++ b/tenseal/sealapi/sealapi_util_namespace.cpp
@@ -8,10 +8,9 @@
 #include <seal/util/croots.h>
 #include <seal/util/hash.h>
 #include <seal/util/hestdparms.h>
+#include <seal/util/iterator.h>
 #include <seal/util/numth.h>
 #include <seal/util/pointer.h>
-#include <seal/util/polyarith.h>
-#include <seal/util/polyarithmod.h>
 #include <seal/util/polyarithsmallmod.h>
 #include <seal/util/rlwe.h>
 #include <seal/util/scalingvariant.h>
@@ -139,7 +138,7 @@ void bind_util_namespace(pybind11::module &m) {
              [](const BaseConverter &obj, const std::vector<std::uint64_t> &in,
                 std::size_t count) {
                  std::vector<std::uint64_t> out(obj.obase_size() * count);
-                 obj.fast_convert_array(in.data(), count, out.data(),
+                 obj.fast_convert_array(ConstRNSIter(in.data(), count), RNSIter(out.data(), count),
                                         MemoryManager::GetPool());
 
                  return out;
@@ -152,45 +151,45 @@ void bind_util_namespace(pybind11::module &m) {
              py::arg(), py::arg(), py::arg(),
              py::arg() = MemoryManager::GetPool())
         .def("divide_and_round_q_last_inplace",
-             [](const RNSTool &obj, std::uint64_t *input) {
-                 obj.divide_and_round_q_last_inplace(input,
+             [](const RNSTool &obj, std::uint64_t *input, std::size_t count) {
+                 obj.divide_and_round_q_last_inplace(RNSIter(input, count),
                                                      MemoryManager::GetPool());
              })
         .def("divide_and_round_q_last_ntt_inplace",
-             [](const RNSTool &obj, std::uint64_t *input,
+             [](const RNSTool &obj, std::uint64_t *input, std::size_t count,
                 const NTTTables *rns_ntt_tables) {
                  obj.divide_and_round_q_last_ntt_inplace(
-                     input, rns_ntt_tables, MemoryManager::GetPool());
+                     RNSIter(input, count), rns_ntt_tables, MemoryManager::GetPool());
              })
         .def("fastbconv_sk",
-             [](const RNSTool &obj, const std::uint64_t *input,
+             [](const RNSTool &obj, const std::uint64_t *input, std::size_t count,
                 std::uint64_t *destination) {
-                 obj.fastbconv_sk(input, destination, MemoryManager::GetPool());
+                 obj.fastbconv_sk(ConstRNSIter(input, count), RNSIter(destination, count), MemoryManager::GetPool());
              })
         .def("sm_mrq",
-             [](const RNSTool &obj, const std::uint64_t *input,
+             [](const RNSTool &obj, const std::uint64_t *input, std::size_t count,
                 std::uint64_t *destination) {
-                 obj.sm_mrq(input, destination, MemoryManager::GetPool());
+                 obj.sm_mrq(ConstRNSIter(input, count), RNSIter(destination, count), MemoryManager::GetPool());
              })
         .def("fast_floor",
-             [](const RNSTool &obj, const std::uint64_t *input,
+             [](const RNSTool &obj, const std::uint64_t *input, std::size_t count,
                 std::uint64_t *destination) {
-                 obj.fast_floor(input, destination, MemoryManager::GetPool());
+                 obj.fast_floor(ConstRNSIter(input, count), RNSIter(destination, count), MemoryManager::GetPool());
              })
         .def("fastbconv_m_tilde",
-             [](const RNSTool &obj, const std::uint64_t *input,
+             [](const RNSTool &obj, const std::uint64_t *input, std::size_t count,
                 std::uint64_t *destination) {
-                 obj.fastbconv_m_tilde(input, destination,
+                 obj.fastbconv_m_tilde(ConstRNSIter(input, count), RNSIter(destination, count),
                                        MemoryManager::GetPool());
              })
         .def("decrypt_scale_and_round",
-             [](const RNSTool &obj, const std::uint64_t *input,
+             [](const RNSTool &obj, const std::uint64_t *input, std::size_t count,
                 std::uint64_t *destination) {
-                 obj.decrypt_scale_and_round(input, destination,
+                 obj.decrypt_scale_and_round(ConstRNSIter(input, count), destination,
                                              MemoryManager::GetPool());
              })
         .def("inv_q_last_mod_q", &RNSTool::inv_q_last_mod_q)
-        .def("base_Bsk_small_ntt_tables", &RNSTool::base_Bsk_small_ntt_tables)
+        .def("base_Bsk_ntt_tables", &RNSTool::base_Bsk_ntt_tables)
         .def("base_q", &RNSTool::base_q)
         .def("base_B", &RNSTool::base_B)
         .def("base_Bsk", &RNSTool::base_Bsk)
@@ -214,12 +213,7 @@ void bind_util_namespace(pybind11::module &m) {
              py::arg(), py::arg() = MemoryManager::GetPool())
         .def("get_root", &NTTTables::get_root)
         .def("get_from_root_powers", &NTTTables::get_from_root_powers)
-        .def("get_from_scaled_root_powers",
-             &NTTTables::get_from_scaled_root_powers)
         .def("get_from_inv_root_powers", &NTTTables::get_from_inv_root_powers)
-        .def("get_from_scaled_inv_root_powers",
-             &NTTTables::get_from_scaled_inv_root_powers)
-        .def("get_inv_degree_modulo", &NTTTables::get_inv_degree_modulo)
         .def("modulus", &NTTTables::modulus)
         .def("coeff_count_power", &NTTTables::coeff_count_power)
         .def("coeff_count", &NTTTables::coeff_count);
@@ -286,106 +280,6 @@ void bind_util_namespace(pybind11::module &m) {
      *******************/
 
     /*******************
-     * "util/polyarith.h" {
-     ***/
-    m.def("right_shift_poly_coeffs",
-          [](const std::vector<uint64_t> &poly, std::size_t coeff_count,
-             std::size_t uint64_cnt, int shift) {
-              std::vector<uint64_t> out(poly.size());
-              right_shift_poly_coeffs(poly.data(), coeff_count, uint64_cnt,
-                                      shift, out.data());
-              return out;
-          })
-        .def("negate_poly",
-             [](const std::vector<uint64_t> &poly, std::size_t coeff_count,
-                std::size_t uint64_cnt) {
-                 std::vector<uint64_t> out(coeff_count);
-                 negate_poly(poly.data(), coeff_count, uint64_cnt, out.data());
-                 return out;
-             })
-        .def("add_poly_poly",
-             [](const std::vector<std::uint64_t> &operand1,
-                const std::vector<std::uint64_t> &operand2,
-                std::size_t coeff_count, std::size_t coeff_uint64_count) {
-                 std::vector<uint64_t> out(coeff_count);
-                 add_poly_poly(operand1.data(), operand2.data(), coeff_count,
-                               coeff_uint64_count, out.data());
-                 return out;
-             })
-        .def("sub_poly_poly",
-             [](const std::vector<std::uint64_t> &operand1,
-                const std::vector<std::uint64_t> &operand2,
-                std::size_t coeff_count, std::size_t coeff_uint64_count) {
-                 std::vector<uint64_t> out(coeff_count);
-                 sub_poly_poly(operand1.data(), operand2.data(), coeff_count,
-                               coeff_uint64_count, out.data());
-                 return out;
-             })
-        .def("multiply_poly_poly",
-             [](const std::vector<std::uint64_t> &operand1,
-                std::size_t operand1_coeff_count,
-                std::size_t operand1_coeff_uint64_count,
-                const std::vector<std::uint64_t> &operand2,
-                std::size_t operand2_coeff_count,
-                std::size_t operand2_coeff_uint64_count,
-                std::size_t result_coeff_count,
-                std::size_t result_coeff_uint64_count) {
-                 std::vector<uint64_t> out(result_coeff_count);
-                 multiply_poly_poly(
-                     operand1.data(), operand1_coeff_count,
-                     operand1_coeff_uint64_count, operand2.data(),
-                     operand2_coeff_count, operand2_coeff_uint64_count,
-                     result_coeff_count, result_coeff_uint64_count, out.data(),
-                     MemoryManager::GetPool());
-                 return out;
-             })
-        .def("poly_infty_norm",
-             [](const std::vector<uint64_t> &poly, std::size_t coeff_count,
-                std::size_t coeff_uint64_count) {
-                 std::vector<uint64_t> out(coeff_count);
-                 poly_infty_norm(poly.data(), coeff_count, coeff_uint64_count,
-                                 out.data());
-                 return out;
-             })
-        .def("poly_eval_poly",
-             [](const std::vector<std::uint64_t> &poly_to_eval,
-                std::size_t poly_to_eval_coeff_count,
-                std::size_t poly_to_eval_coeff_uint64_count,
-                const std::vector<std::uint64_t> &value,
-                std::size_t value_coeff_count,
-                std::size_t value_coeff_uint64_count,
-                std::size_t result_coeff_count,
-                std::size_t result_coeff_uint64_count
-
-             ) {
-                 std::vector<uint64_t> out(result_coeff_count);
-                 poly_eval_poly(poly_to_eval.data(), poly_to_eval_coeff_count,
-                                poly_to_eval_coeff_uint64_count, value.data(),
-                                value_coeff_count, value_coeff_uint64_count,
-                                result_coeff_count, result_coeff_uint64_count,
-                                out.data(), MemoryManager::GetPool());
-                 return out;
-             })
-        .def("exponentiate_poly", [](const std::vector<std::uint64_t> poly,
-                                     std::size_t poly_coeff_count,
-                                     std::size_t poly_coeff_uint64_count,
-                                     const std::vector<std::uint64_t> &exponent,
-                                     std::size_t exponent_uint64_count,
-                                     std::size_t result_coeff_count,
-                                     std::size_t result_coeff_uint64_count) {
-            std::vector<uint64_t> out(result_coeff_count);
-            exponentiate_poly(poly.data(), poly_coeff_count,
-                              poly_coeff_uint64_count, exponent.data(),
-                              exponent_uint64_count, result_coeff_count,
-                              result_coeff_uint64_count, out.data(),
-                              MemoryManager::GetPool());
-            return out;
-        });
-    /***
-     * } "util/polyarith.h"
-     *******************/
-
-    /*******************
      * "util/rlwe.h" {
      ***/
     m.def("sample_poly_ternary",
@@ -429,14 +323,6 @@ void bind_util_namespace(pybind11::module &m) {
               modulo_poly_coeffs(poly.data(), coeff_count, modulus, out.data());
               return out;
           })
-        .def("modulo_poly_coeffs_63",
-             [](const std::vector<uint64_t> &poly, std::size_t coeff_count,
-                const Modulus &modulus) {
-                 std::vector<uint64_t> out(coeff_count);
-                 modulo_poly_coeffs_63(poly.data(), coeff_count, modulus,
-                                       out.data());
-                 return out;
-             })
         .def("negate_poly_coeffmod",
              [](const std::vector<uint64_t> &poly, std::size_t coeff_count,
                 const Modulus &modulus) {
@@ -445,21 +331,21 @@ void bind_util_namespace(pybind11::module &m) {
                                       out.data());
                  return out;
              })
-        .def("add_poly_poly_coeffmod",
+        .def("add_poly_coeffmod",
              [](const std::vector<uint64_t> &operand1,
                 const std::vector<uint64_t> &operand2, std::size_t coeff_count,
                 const Modulus &modulus) {
                  std::vector<uint64_t> out(coeff_count);
-                 add_poly_poly_coeffmod(operand1.data(), operand2.data(),
+                 add_poly_coeffmod(operand1.data(), operand2.data(),
                                         coeff_count, modulus, out.data());
                  return out;
              })
-        .def("sub_poly_poly_coeffmod",
+        .def("sub_poly_coeffmod",
              [](const std::vector<uint64_t> &operand1,
                 const std::vector<uint64_t> &operand2, std::size_t coeff_count,
                 const Modulus &modulus) {
                  std::vector<uint64_t> out(coeff_count);
-                 sub_poly_poly_coeffmod(operand1.data(), operand2.data(),
+                 sub_poly_coeffmod(operand1.data(), operand2.data(),
                                         coeff_count, modulus, out.data());
                  return out;
              })
@@ -470,51 +356,6 @@ void bind_util_namespace(pybind11::module &m) {
                  multiply_poly_scalar_coeffmod(poly.data(), coeff_count, scalar,
                                                modulus, out.data());
                  return out;
-             })
-        .def("multiply_poly_poly_coeffmod",
-             [](const std::vector<std::uint64_t> &operand1,
-                std::size_t operand1_coeff_count,
-                const std::vector<std::uint64_t> &operand2,
-                std::size_t operand2_coeff_count, const Modulus &modulus,
-                std::size_t result_coeff_count) {
-                 std::vector<uint64_t> out(result_coeff_count);
-                 multiply_poly_poly_coeffmod(
-                     operand1.data(), operand1_coeff_count, operand2.data(),
-                     operand2_coeff_count, modulus, result_coeff_count,
-                     out.data());
-                 return out;
-             })
-        .def("multiply_poly_poly_coeffmod",
-             [](const std::vector<std::uint64_t> &operand1,
-                const std::vector<std::uint64_t> &operand2,
-                std::size_t coeff_count, const Modulus &modulus,
-                std::size_t result_coeff_count) {
-                 std::vector<uint64_t> out(coeff_count * coeff_count);
-                 multiply_poly_poly_coeffmod(operand1.data(), operand2.data(),
-                                             coeff_count, modulus, out.data());
-                 return out;
-             })
-        .def("multiply_truncate_poly_poly_coeffmod",
-             [](const std::vector<std::uint64_t> &operand1,
-                const std::vector<std::uint64_t> &operand2,
-                std::size_t coeff_count, const Modulus &modulus,
-                std::size_t result_coeff_count) {
-                 std::vector<uint64_t> out(coeff_count * coeff_count);
-                 multiply_truncate_poly_poly_coeffmod(
-                     operand1.data(), operand2.data(), coeff_count, modulus,
-                     out.data());
-                 return out;
-             })
-        .def("divide_poly_poly_coeffmod",
-             [](const std::vector<std::uint64_t> &operand1,
-                const std::vector<std::uint64_t> &operand2,
-                std::size_t coeff_count, const Modulus &modulus) {
-                 std::vector<uint64_t> q(coeff_count);
-                 std::vector<uint64_t> r(coeff_count);
-                 divide_poly_poly_coeffmod(operand1.data(), operand2.data(),
-                                           coeff_count, modulus, q.data(),
-                                           r.data());
-                 return std::vector<std::vector<uint64_t>>{q, r};
              })
         .def("dyadic_product_coeffmod",
              [](const std::vector<std::uint64_t> &operand1,
@@ -531,16 +372,6 @@ void bind_util_namespace(pybind11::module &m) {
                 const Modulus &modulus) {
                  return poly_infty_norm_coeffmod(poly.data(), coeff_count,
                                                  modulus);
-             })
-        .def("try_invert_poly_coeffmod",
-             [](const std::vector<uint64_t> &poly,
-                const std::vector<uint64_t> &poly_modulus,
-                std::size_t coeff_count, const Modulus &modulus) {
-                 std::vector<uint64_t> out(coeff_count);
-                 try_invert_poly_coeffmod(poly.data(), poly_modulus.data(),
-                                          coeff_count, modulus, out.data(),
-                                          MemoryManager::GetPool());
-                 return out;
              })
         .def("negacyclic_shift_poly_coeffmod",
              [](const std::vector<uint64_t> &poly, std::size_t coeff_count,
@@ -562,58 +393,6 @@ void bind_util_namespace(pybind11::module &m) {
              });
     /***
      * } "util/polyarithsmallmod.h"
-     *******************/
-
-    /*******************
-     * "util/polyarithmod.h" {
-     ***/
-    m.def("negate_poly_coeffmod",
-          [](const std::vector<uint64_t> &poly, std::size_t coeff_count,
-             const std::vector<uint64_t> &coeff_modulus,
-             std::size_t coeff_uint64_count) {
-              std::vector<uint64_t> out(coeff_count);
-              negate_poly_coeffmod(poly.data(), coeff_count,
-                                   coeff_modulus.data(), coeff_uint64_count,
-                                   out.data());
-              return out;
-          })
-        .def("add_poly_poly_coeffmod",
-             [](const std::vector<std::uint64_t> &operand1,
-                const std::vector<std::uint64_t> operand2,
-                std::size_t coeff_count,
-                const std::vector<std::uint64_t> &coeff_modulus,
-                std::size_t coeff_uint64_count) {
-                 std::vector<uint64_t> out(coeff_count);
-                 add_poly_poly_coeffmod(operand1.data(), operand2.data(),
-                                        coeff_count, coeff_modulus.data(),
-                                        coeff_uint64_count, out.data());
-                 return out;
-             })
-        .def("sub_poly_poly_coeffmod",
-             [](const std::vector<std::uint64_t> &operand1,
-                const std::vector<std::uint64_t> operand2,
-                std::size_t coeff_count,
-                const std::vector<std::uint64_t> &coeff_modulus,
-                std::size_t coeff_uint64_count) {
-                 std::vector<uint64_t> out(coeff_count);
-                 sub_poly_poly_coeffmod(operand1.data(), operand2.data(),
-                                        coeff_count, coeff_modulus.data(),
-                                        coeff_uint64_count, out.data());
-                 return out;
-             })
-        .def("poly_infty_norm_coeffmod",
-             [](const std::vector<std::uint64_t> &poly, std::size_t coeff_count,
-                std::size_t coeff_uint64_count,
-                const std::vector<std::uint64_t> &modulus) {
-                 std::vector<uint64_t> out(coeff_count);
-                 poly_infty_norm_coeffmod(poly.data(), coeff_count,
-                                          coeff_uint64_count, modulus.data(),
-                                          out.data(), MemoryManager::GetPool());
-                 return out;
-             });
-
-    /***
-     * } "util/polyarithmod.h"
      *******************/
 
     /*******************
@@ -716,6 +495,12 @@ void bind_util_namespace(pybind11::module &m) {
      * } "util/hash.h"
      *******************/
 
+    py::class_<MultiplyUIntModOperand>(m, "MultiplyUIntModOperand", py::module_local())
+        .def(py::init<>())
+        .def_readwrite("operand", &MultiplyUIntModOperand::operand)
+        .def_readwrite("quotient", &MultiplyUIntModOperand::quotient);
+
+
     /*******************
      * "util/pointer.h" {
      ***/
@@ -726,6 +511,7 @@ void bind_util_namespace(pybind11::module &m) {
     bind_pointer<NTTTables>(m, "NTTTables");
     bind_pointer<RNSTool>(m, "RNSTool");
     bind_pointer<RNSBase>(m, "RNSBase");
+    bind_pointer<MultiplyUIntModOperand>(m, "MultiplyUIntModOperand");
 
     /***
      * } "util/pointer.h"

--- a/tenseal/sealapi/sealapi_util_namespace.cpp
+++ b/tenseal/sealapi/sealapi_util_namespace.cpp
@@ -138,7 +138,8 @@ void bind_util_namespace(pybind11::module &m) {
              [](const BaseConverter &obj, const std::vector<std::uint64_t> &in,
                 std::size_t count) {
                  std::vector<std::uint64_t> out(obj.obase_size() * count);
-                 obj.fast_convert_array(ConstRNSIter(in.data(), count), RNSIter(out.data(), count),
+                 obj.fast_convert_array(ConstRNSIter(in.data(), count),
+                                        RNSIter(out.data(), count),
                                         MemoryManager::GetPool());
 
                  return out;
@@ -159,33 +160,42 @@ void bind_util_namespace(pybind11::module &m) {
              [](const RNSTool &obj, std::uint64_t *input, std::size_t count,
                 const NTTTables *rns_ntt_tables) {
                  obj.divide_and_round_q_last_ntt_inplace(
-                     RNSIter(input, count), rns_ntt_tables, MemoryManager::GetPool());
+                     RNSIter(input, count), rns_ntt_tables,
+                     MemoryManager::GetPool());
              })
         .def("fastbconv_sk",
-             [](const RNSTool &obj, const std::uint64_t *input, std::size_t count,
-                std::uint64_t *destination) {
-                 obj.fastbconv_sk(ConstRNSIter(input, count), RNSIter(destination, count), MemoryManager::GetPool());
+             [](const RNSTool &obj, const std::uint64_t *input,
+                std::size_t count, std::uint64_t *destination) {
+                 obj.fastbconv_sk(ConstRNSIter(input, count),
+                                  RNSIter(destination, count),
+                                  MemoryManager::GetPool());
              })
         .def("sm_mrq",
-             [](const RNSTool &obj, const std::uint64_t *input, std::size_t count,
-                std::uint64_t *destination) {
-                 obj.sm_mrq(ConstRNSIter(input, count), RNSIter(destination, count), MemoryManager::GetPool());
+             [](const RNSTool &obj, const std::uint64_t *input,
+                std::size_t count, std::uint64_t *destination) {
+                 obj.sm_mrq(ConstRNSIter(input, count),
+                            RNSIter(destination, count),
+                            MemoryManager::GetPool());
              })
         .def("fast_floor",
-             [](const RNSTool &obj, const std::uint64_t *input, std::size_t count,
-                std::uint64_t *destination) {
-                 obj.fast_floor(ConstRNSIter(input, count), RNSIter(destination, count), MemoryManager::GetPool());
+             [](const RNSTool &obj, const std::uint64_t *input,
+                std::size_t count, std::uint64_t *destination) {
+                 obj.fast_floor(ConstRNSIter(input, count),
+                                RNSIter(destination, count),
+                                MemoryManager::GetPool());
              })
         .def("fastbconv_m_tilde",
-             [](const RNSTool &obj, const std::uint64_t *input, std::size_t count,
-                std::uint64_t *destination) {
-                 obj.fastbconv_m_tilde(ConstRNSIter(input, count), RNSIter(destination, count),
+             [](const RNSTool &obj, const std::uint64_t *input,
+                std::size_t count, std::uint64_t *destination) {
+                 obj.fastbconv_m_tilde(ConstRNSIter(input, count),
+                                       RNSIter(destination, count),
                                        MemoryManager::GetPool());
              })
         .def("decrypt_scale_and_round",
-             [](const RNSTool &obj, const std::uint64_t *input, std::size_t count,
-                std::uint64_t *destination) {
-                 obj.decrypt_scale_and_round(ConstRNSIter(input, count), destination,
+             [](const RNSTool &obj, const std::uint64_t *input,
+                std::size_t count, std::uint64_t *destination) {
+                 obj.decrypt_scale_and_round(ConstRNSIter(input, count),
+                                             destination,
                                              MemoryManager::GetPool());
              })
         .def("inv_q_last_mod_q", &RNSTool::inv_q_last_mod_q)
@@ -337,7 +347,7 @@ void bind_util_namespace(pybind11::module &m) {
                 const Modulus &modulus) {
                  std::vector<uint64_t> out(coeff_count);
                  add_poly_coeffmod(operand1.data(), operand2.data(),
-                                        coeff_count, modulus, out.data());
+                                   coeff_count, modulus, out.data());
                  return out;
              })
         .def("sub_poly_coeffmod",
@@ -346,7 +356,7 @@ void bind_util_namespace(pybind11::module &m) {
                 const Modulus &modulus) {
                  std::vector<uint64_t> out(coeff_count);
                  sub_poly_coeffmod(operand1.data(), operand2.data(),
-                                        coeff_count, modulus, out.data());
+                                   coeff_count, modulus, out.data());
                  return out;
              })
         .def("multiply_poly_scalar_coeffmod",
@@ -495,11 +505,11 @@ void bind_util_namespace(pybind11::module &m) {
      * } "util/hash.h"
      *******************/
 
-    py::class_<MultiplyUIntModOperand>(m, "MultiplyUIntModOperand", py::module_local())
+    py::class_<MultiplyUIntModOperand>(m, "MultiplyUIntModOperand",
+                                       py::module_local())
         .def(py::init<>())
         .def_readwrite("operand", &MultiplyUIntModOperand::operand)
         .def_readwrite("quotient", &MultiplyUIntModOperand::quotient);
-
 
     /*******************
      * "util/pointer.h" {

--- a/tenseal/sealapi/sealapi_util_namespace.cpp
+++ b/tenseal/sealapi/sealapi_util_namespace.cpp
@@ -158,6 +158,7 @@ void bind_util_namespace(pybind11::module &m) {
                  obj.divide_and_round_q_last_inplace(
                      RNSIter(input.data(), poly_modulus_degree),
                      MemoryManager::GetPool());
+                 return input;
              })
         .def("divide_and_round_q_last_ntt_inplace",
              [](const RNSTool &obj, std::vector<uint64_t> &input,
@@ -166,49 +167,59 @@ void bind_util_namespace(pybind11::module &m) {
                  obj.divide_and_round_q_last_ntt_inplace(
                      RNSIter(input.data(), poly_modulus_degree), rns_ntt_tables,
                      MemoryManager::GetPool());
+                 return input;
              })
         .def("fastbconv_sk",
              [](const RNSTool &obj, const std::vector<uint64_t> &input,
-                std::vector<uint64_t> &destination,
                 std::size_t poly_modulus_degree) {
+                 std::vector<uint64_t> out(poly_modulus_degree *
+                                           obj.base_q()->size());
                  obj.fastbconv_sk(
                      ConstRNSIter(input.data(), poly_modulus_degree),
-                     RNSIter(destination.data(), poly_modulus_degree),
+                     RNSIter(out.data(), poly_modulus_degree),
                      MemoryManager::GetPool());
+                 return out;
              })
         .def("sm_mrq",
              [](const RNSTool &obj, const std::vector<uint64_t> &input,
-                std::vector<uint64_t> &destination,
                 std::size_t poly_modulus_degree) {
+                 std::vector<uint64_t> out(poly_modulus_degree *
+                                           obj.base_Bsk()->size());
                  obj.sm_mrq(ConstRNSIter(input.data(), poly_modulus_degree),
-                            RNSIter(destination.data(), poly_modulus_degree),
+                            RNSIter(out.data(), poly_modulus_degree),
                             MemoryManager::GetPool());
+                 return out;
              })
         .def("fast_floor",
              [](const RNSTool &obj, const std::vector<uint64_t> &input,
-                std::vector<uint64_t> &destination,
                 std::size_t poly_modulus_degree) {
-                 obj.fast_floor(
-                     ConstRNSIter(input.data(), poly_modulus_degree),
-                     RNSIter(destination.data(), poly_modulus_degree),
-                     MemoryManager::GetPool());
+                 std::vector<uint64_t> out(poly_modulus_degree *
+                                           obj.base_Bsk()->size());
+                 obj.fast_floor(ConstRNSIter(input.data(), poly_modulus_degree),
+                                RNSIter(out.data(), poly_modulus_degree),
+                                MemoryManager::GetPool());
+                 return out;
              })
         .def("fastbconv_m_tilde",
              [](const RNSTool &obj, const std::vector<uint64_t> &input,
-                std::vector<uint64_t> &destination,
                 std::size_t poly_modulus_degree) {
+                 std::vector<uint64_t> out(poly_modulus_degree *
+                                           obj.base_Bsk_m_tilde()->size());
                  obj.fastbconv_m_tilde(
                      ConstRNSIter(input.data(), poly_modulus_degree),
-                     RNSIter(destination.data(), poly_modulus_degree),
+                     RNSIter(out.data(), poly_modulus_degree),
                      MemoryManager::GetPool());
+                 return out;
              })
         .def("decrypt_scale_and_round",
              [](const RNSTool &obj, const std::vector<uint64_t> &input,
-                std::vector<uint64_t> &destination,
                 std::size_t poly_modulus_degree) {
+                 std::vector<uint64_t> out(poly_modulus_degree *
+                                           obj.base_q()->size());
                  obj.decrypt_scale_and_round(
                      ConstRNSIter(input.data(), poly_modulus_degree),
-                     CoeffIter(destination.data()), MemoryManager::GetPool());
+                     CoeffIter(out.data()), MemoryManager::GetPool());
+                 return out;
              })
         .def("inv_q_last_mod_q", &RNSTool::inv_q_last_mod_q)
         .def("base_Bsk_ntt_tables", &RNSTool::base_Bsk_ntt_tables)

--- a/tenseal/sealapi/sealapi_util_namespace.cpp
+++ b/tenseal/sealapi/sealapi_util_namespace.cpp
@@ -134,16 +134,17 @@ void bind_util_namespace(pybind11::module &m) {
                                  MemoryManager::GetPool());
                 return out;
             })
-        .def("fast_convert_array",
-             [](const BaseConverter &obj, const std::vector<std::uint64_t> &in,
-                std::size_t count) {
-                 std::vector<std::uint64_t> out(obj.obase_size() * count);
-                 obj.fast_convert_array(ConstRNSIter(in.data(), count),
-                                        RNSIter(out.data(), count),
-                                        MemoryManager::GetPool());
+        .def("fast_convert_array", [](const BaseConverter &obj,
+                                      const std::vector<std::uint64_t> &in,
+                                      std::size_t poly_modulus_degree) {
+            std::vector<std::uint64_t> out(obj.obase_size() *
+                                           poly_modulus_degree);
+            obj.fast_convert_array(ConstRNSIter(in.data(), poly_modulus_degree),
+                                   RNSIter(out.data(), poly_modulus_degree),
+                                   MemoryManager::GetPool());
 
-                 return out;
-             });
+            return out;
+        });
 
     py::class_<RNSTool, std::shared_ptr<RNSTool>>(m, "RNSTool",
                                                   py::module_local())
@@ -152,51 +153,62 @@ void bind_util_namespace(pybind11::module &m) {
              py::arg(), py::arg(), py::arg(),
              py::arg() = MemoryManager::GetPool())
         .def("divide_and_round_q_last_inplace",
-             [](const RNSTool &obj, std::uint64_t *input, std::size_t count) {
-                 obj.divide_and_round_q_last_inplace(RNSIter(input, count),
-                                                     MemoryManager::GetPool());
+             [](const RNSTool &obj, std::vector<uint64_t> &input,
+                std::size_t poly_modulus_degree) {
+                 obj.divide_and_round_q_last_inplace(
+                     RNSIter(input.data(), poly_modulus_degree),
+                     MemoryManager::GetPool());
              })
         .def("divide_and_round_q_last_ntt_inplace",
-             [](const RNSTool &obj, std::uint64_t *input, std::size_t count,
+             [](const RNSTool &obj, std::vector<uint64_t> &input,
+                std::size_t poly_modulus_degree,
                 const NTTTables *rns_ntt_tables) {
                  obj.divide_and_round_q_last_ntt_inplace(
-                     RNSIter(input, count), rns_ntt_tables,
+                     RNSIter(input.data(), poly_modulus_degree), rns_ntt_tables,
                      MemoryManager::GetPool());
              })
         .def("fastbconv_sk",
-             [](const RNSTool &obj, const std::uint64_t *input,
-                std::size_t count, std::uint64_t *destination) {
-                 obj.fastbconv_sk(ConstRNSIter(input, count),
-                                  RNSIter(destination, count),
-                                  MemoryManager::GetPool());
+             [](const RNSTool &obj, const std::vector<uint64_t> &input,
+                std::vector<uint64_t> &destination,
+                std::size_t poly_modulus_degree) {
+                 obj.fastbconv_sk(
+                     ConstRNSIter(input.data(), poly_modulus_degree),
+                     RNSIter(destination.data(), poly_modulus_degree),
+                     MemoryManager::GetPool());
              })
         .def("sm_mrq",
-             [](const RNSTool &obj, const std::uint64_t *input,
-                std::size_t count, std::uint64_t *destination) {
-                 obj.sm_mrq(ConstRNSIter(input, count),
-                            RNSIter(destination, count),
+             [](const RNSTool &obj, const std::vector<uint64_t> &input,
+                std::vector<uint64_t> &destination,
+                std::size_t poly_modulus_degree) {
+                 obj.sm_mrq(ConstRNSIter(input.data(), poly_modulus_degree),
+                            RNSIter(destination.data(), poly_modulus_degree),
                             MemoryManager::GetPool());
              })
         .def("fast_floor",
-             [](const RNSTool &obj, const std::uint64_t *input,
-                std::size_t count, std::uint64_t *destination) {
-                 obj.fast_floor(ConstRNSIter(input, count),
-                                RNSIter(destination, count),
-                                MemoryManager::GetPool());
+             [](const RNSTool &obj, const std::vector<uint64_t> &input,
+                std::vector<uint64_t> &destination,
+                std::size_t poly_modulus_degree) {
+                 obj.fast_floor(
+                     ConstRNSIter(input.data(), poly_modulus_degree),
+                     RNSIter(destination.data(), poly_modulus_degree),
+                     MemoryManager::GetPool());
              })
         .def("fastbconv_m_tilde",
-             [](const RNSTool &obj, const std::uint64_t *input,
-                std::size_t count, std::uint64_t *destination) {
-                 obj.fastbconv_m_tilde(ConstRNSIter(input, count),
-                                       RNSIter(destination, count),
-                                       MemoryManager::GetPool());
+             [](const RNSTool &obj, const std::vector<uint64_t> &input,
+                std::vector<uint64_t> &destination,
+                std::size_t poly_modulus_degree) {
+                 obj.fastbconv_m_tilde(
+                     ConstRNSIter(input.data(), poly_modulus_degree),
+                     RNSIter(destination.data(), poly_modulus_degree),
+                     MemoryManager::GetPool());
              })
         .def("decrypt_scale_and_round",
-             [](const RNSTool &obj, const std::uint64_t *input,
-                std::size_t count, std::uint64_t *destination) {
-                 obj.decrypt_scale_and_round(ConstRNSIter(input, count),
-                                             destination,
-                                             MemoryManager::GetPool());
+             [](const RNSTool &obj, const std::vector<uint64_t> &input,
+                std::vector<uint64_t> &destination,
+                std::size_t poly_modulus_degree) {
+                 obj.decrypt_scale_and_round(
+                     ConstRNSIter(input.data(), poly_modulus_degree),
+                     CoeffIter(destination.data()), MemoryManager::GetPool());
              })
         .def("inv_q_last_mod_q", &RNSTool::inv_q_last_mod_q)
         .def("base_Bsk_ntt_tables", &RNSTool::base_Bsk_ntt_tables)
@@ -509,7 +521,9 @@ void bind_util_namespace(pybind11::module &m) {
                                        py::module_local())
         .def(py::init<>())
         .def_readwrite("operand", &MultiplyUIntModOperand::operand)
-        .def_readwrite("quotient", &MultiplyUIntModOperand::quotient);
+        .def_readwrite("quotient", &MultiplyUIntModOperand::quotient)
+        .def("set_quotient", &MultiplyUIntModOperand::set_quotient)
+        .def("set", &MultiplyUIntModOperand::set);
 
     /*******************
      * "util/pointer.h" {

--- a/tenseal/sealapi/util/__init__.py
+++ b/tenseal/sealapi/util/__init__.py
@@ -16,22 +16,6 @@ inverse_ntt_negacyclic_harvey = _sealapi_util_cpp.inverse_ntt_negacyclic_harvey
 ## util/galois.h ##
 GaloisTool = _sealapi_util_cpp.GaloisTool
 
-## util/polyarith.h ##
-right_shift_poly_coeffs = _sealapi_util_cpp.right_shift_poly_coeffs
-negate_poly = _sealapi_util_cpp.negate_poly
-add_poly_poly = _sealapi_util_cpp.add_poly_poly
-sub_poly_poly = _sealapi_util_cpp.sub_poly_poly
-multiply_poly_poly = _sealapi_util_cpp.multiply_poly_poly
-poly_infty_norm = _sealapi_util_cpp.poly_infty_norm
-poly_eval_poly = _sealapi_util_cpp.poly_eval_poly
-exponentiate_poly = _sealapi_util_cpp.exponentiate_poly
-
-## util/polyarithmod.h ##
-negate_poly_coeffmod = _sealapi_util_cpp.negate_poly_coeffmod
-add_poly_poly_coeffmod = _sealapi_util_cpp.add_poly_poly_coeffmod
-sub_poly_poly_coeffmod = _sealapi_util_cpp.sub_poly_poly_coeffmod
-poly_infty_norm_coeffmod = _sealapi_util_cpp.poly_infty_norm_coeffmod
-
 ## util/polycore.h ##
 poly_to_hex_string = _sealapi_util_cpp.poly_to_hex_string
 poly_to_dec_string = _sealapi_util_cpp.poly_to_dec_string
@@ -44,17 +28,12 @@ sample_poly_uniform = _sealapi_util_cpp.sample_poly_uniform
 
 ## util/polyarithsmallmod.h ##
 modulo_poly_coeffs = _sealapi_util_cpp.modulo_poly_coeffs
-modulo_poly_coeffs_63 = _sealapi_util_cpp.modulo_poly_coeffs_63
 negate_poly_coeffmod = _sealapi_util_cpp.negate_poly_coeffmod
-add_poly_poly_coeffmod = _sealapi_util_cpp.add_poly_poly_coeffmod
-sub_poly_poly_coeffmod = _sealapi_util_cpp.sub_poly_poly_coeffmod
+add_poly_coeffmod = _sealapi_util_cpp.add_poly_coeffmod
+sub_poly_coeffmod = _sealapi_util_cpp.sub_poly_coeffmod
 multiply_poly_scalar_coeffmod = _sealapi_util_cpp.multiply_poly_scalar_coeffmod
-multiply_poly_poly_coeffmod = _sealapi_util_cpp.multiply_poly_poly_coeffmod
-multiply_truncate_poly_poly_coeffmod = _sealapi_util_cpp.multiply_truncate_poly_poly_coeffmod
-divide_poly_poly_coeffmod = _sealapi_util_cpp.divide_poly_poly_coeffmod
 dyadic_product_coeffmod = _sealapi_util_cpp.dyadic_product_coeffmod
 poly_infty_norm_coeffmod = _sealapi_util_cpp.poly_infty_norm_coeffmod
-try_invert_poly_coeffmod = _sealapi_util_cpp.try_invert_poly_coeffmod
 negacyclic_shift_poly_coeffmod = _sealapi_util_cpp.negacyclic_shift_poly_coeffmod
 negacyclic_multiply_poly_mono_coeffmod = _sealapi_util_cpp.negacyclic_multiply_poly_mono_coeffmod
 

--- a/tenseal/sealapi/util/__init__.py
+++ b/tenseal/sealapi/util/__init__.py
@@ -72,3 +72,6 @@ PointerModulus = _sealapi_util_cpp.PointerModulus
 PointerGaloisTool = _sealapi_util_cpp.PointerGaloisTool
 PointerNTTTables = _sealapi_util_cpp.PointerNTTTables
 PointerRNSTool = _sealapi_util_cpp.PointerRNSTool
+
+## util/uinitarithsmallmod.h ##
+MultiplyUIntModOperand = _sealapi_util_cpp.MultiplyUIntModOperand

--- a/tests/sealapi/test_context.py
+++ b/tests/sealapi/test_context.py
@@ -144,7 +144,8 @@ def context_asserts(sealctx, sec_level, scheme):
         assert ctx_data.total_coeff_modulus_bit_count() == ctx_alias.total_coeff_modulus_bit_count()
 
         assert ctx_data.plain_upper_half_threshold() == ctx_alias.plain_upper_half_threshold()
-        assert ctx_data.coeff_div_plain_modulus() == ctx_alias.coeff_div_plain_modulus()
+        if scheme == sealapi.SCHEME_TYPE.BFV:
+            assert ctx_data.coeff_div_plain_modulus().operand == ctx_alias.coeff_div_plain_modulus().operand
         assert ctx_data.upper_half_increment() == ctx_alias.upper_half_increment()
         assert ctx_data.upper_half_threshold() == ctx_alias.upper_half_threshold()
 

--- a/tests/sealapi/test_context.py
+++ b/tests/sealapi/test_context.py
@@ -145,7 +145,10 @@ def context_asserts(sealctx, sec_level, scheme):
 
         assert ctx_data.plain_upper_half_threshold() == ctx_alias.plain_upper_half_threshold()
         if scheme == sealapi.SCHEME_TYPE.BFV:
-            assert ctx_data.coeff_div_plain_modulus().operand == ctx_alias.coeff_div_plain_modulus().operand
+            assert (
+                ctx_data.coeff_div_plain_modulus().operand
+                == ctx_alias.coeff_div_plain_modulus().operand
+            )
         assert ctx_data.upper_half_increment() == ctx_alias.upper_half_increment()
         assert ctx_data.upper_half_threshold() == ctx_alias.upper_half_threshold()
 

--- a/tests/sealapi/test_util.py
+++ b/tests/sealapi/test_util.py
@@ -258,6 +258,59 @@ def test_util_rnstool_sanity():
     coeff_base = util.RNSBase([sealapi.Modulus(3)])
     rns_tool = util.RNSTool(poly_modulus_degree, coeff_base, plain)
 
+    input = [1, 2, 1, 2]
+    dest = rns_tool.fastbconv_sk(input, poly_modulus_degree)
+    assert dest == [1, 2]
+
+    input = [
+        rns_tool.m_tilde().value(),
+        2 * rns_tool.m_tilde().value(),
+        rns_tool.m_tilde().value(),
+        2 * rns_tool.m_tilde().value(),
+        0,
+        0,
+    ]
+    dest = rns_tool.sm_mrq(input, poly_modulus_degree)
+    assert dest == [1, 2, 1, 2]
+
+    input = [15, 3, 15, 3, 15, 3]
+    dest = rns_tool.fast_floor(input, poly_modulus_degree)
+    assert dest == [5, 1, 5, 1]
+
+    input = [1, 2]
+    dest = rns_tool.fastbconv_m_tilde(input, poly_modulus_degree)
+    assert dest == [1, 2, 1, 2, 1, 2]
+
+    poly_modulus_degree = 2
+    plain = sealapi.Modulus(3)
+    coeff_base = util.RNSBase([sealapi.Modulus(5), sealapi.Modulus(7)])
+    rns_tool = util.RNSTool(poly_modulus_degree, coeff_base, plain)
+
+    input = [35, 70, 35, 70]
+    dest = rns_tool.decrypt_scale_and_round(input, poly_modulus_degree)
+    assert dest == [0, 0, 0, 0]
+    input = [29, 30 + 35, 29, 30 + 35]
+    dest = rns_tool.decrypt_scale_and_round(input, poly_modulus_degree)
+    assert dest == [2, 0, 0, 0]
+
+    poly_modulus_degree = 2
+    plain = sealapi.Modulus(0)
+    coeff_base = util.RNSBase([sealapi.Modulus(13), sealapi.Modulus(7)])
+    rns_tool = util.RNSTool(poly_modulus_degree, coeff_base, plain)
+
+    input = [12, 11, 4, 3]
+    dest = rns_tool.divide_and_round_q_last_inplace(input, poly_modulus_degree)
+    assert dest == [4, 3, 0, 6]
+
+    poly_modulus_degree = 2
+    plain = sealapi.Modulus(0)
+    coeff_base = util.RNSBase([sealapi.Modulus(53), sealapi.Modulus(13)])
+    rns_tool = util.RNSTool(poly_modulus_degree, coeff_base, plain)
+
+    input = [4, 12, 4, 12]
+    dest = rns_tool.divide_and_round_q_last_inplace(input, poly_modulus_degree)
+    assert dest == [0, 1, 10, 5]
+
 
 def test_util_multiplyuintmodoperand_sanity():
     mod = sealapi.Modulus(2147483647)

--- a/tests/sealapi/test_util.py
+++ b/tests/sealapi/test_util.py
@@ -257,3 +257,12 @@ def test_util_rnstool_sanity():
     plain = sealapi.Modulus(0)
     coeff_base = util.RNSBase([sealapi.Modulus(3)])
     rns_tool = util.RNSTool(poly_modulus_degree, coeff_base, plain)
+
+
+def test_util_multiplyuintmodoperand_sanity():
+    mod = sealapi.Modulus(2147483647)
+    op = util.MultiplyUIntModOperand()
+    op.set(2147483646, mod)
+    op.set_quotient(mod)
+    assert op.operand == 2147483646
+    assert op.quotient == 18446744065119617019

--- a/tests/sealapi/test_util.py
+++ b/tests/sealapi/test_util.py
@@ -51,9 +51,9 @@ def test_util_rns():
 
     base = util.RNSBase([sealapi.Modulus(3), sealapi.Modulus(5)])
     dec = base.decompose_array([14, 0], 1)
-    assert dec == [4, 0]
+    assert dec == [2, 4]
     comp = base.compose_array(dec, 1)
-    assert comp == [10, 0]
+    assert comp == [14, 0]
 
     assert base.base_prod() == 15
 
@@ -122,58 +122,19 @@ def test_util_croots():
     assert croot.get_root(5) != 0
 
 
-def test_util_polyarith():
-    assert util.right_shift_poly_coeffs([2, 4, 8], 3, 1, 1) == [1, 2, 4]
-    assert util.negate_poly([2, 4, 8], 3, 1) == [(1 << 64) - 2, (1 << 64) - 4, (1 << 64) - 8]
-    assert util.add_poly_poly([2, 4, 8], [3, 4, 5], 3, 1) == [5, 8, 13]
-    assert util.sub_poly_poly([4, 6, 8], [3, 4, 5], 3, 1) == [1, 2, 3]
-    assert util.multiply_poly_poly([1, 2], 2, 1, [1, 2, 3], 3, 1, 4, 1) == [1, 4, 7, 6]
-    assert util.poly_infty_norm([1, 2], 2, 1) == [2, 0]
-    assert util.poly_eval_poly([1, 0], 2, 1, [2, 1], 2, 1, 4, 1) == [1, 0, 0, 0]
-    assert util.exponentiate_poly([2, 3], 2, 1, [2], 1, 4, 1) == [4, 12, 9, 0]
-
-
 def test_util_polyarithsmallmod():
     assert util.modulo_poly_coeffs([5, 6, 7, 8, 9], 5, sealapi.Modulus(2)) == [1, 0, 1, 0, 1]
-    assert util.modulo_poly_coeffs_63([66, 67, 68], 3, sealapi.Modulus(5)) == [1, 2, 3]
     assert util.negate_poly_coeffmod([1, 2], 2, sealapi.Modulus(5)) == [4, 3]
-    assert util.add_poly_poly_coeffmod([1, 2], [1, 2], 2, sealapi.Modulus(5)) == [2, 4]
-    assert util.sub_poly_poly_coeffmod([1, 2], [1, 2], 2, sealapi.Modulus(5)) == [0, 0]
+    assert util.add_poly_coeffmod([1, 2], [1, 2], 2, sealapi.Modulus(5)) == [2, 4]
+    assert util.sub_poly_coeffmod([1, 2], [1, 2], 2, sealapi.Modulus(5)) == [0, 0]
     assert util.multiply_poly_scalar_coeffmod([1, 2], 2, 3, sealapi.Modulus(5)) == [3, 1]
-    assert util.multiply_poly_poly_coeffmod([1, 2], 2, [2, 3], 2, sealapi.Modulus(5), 4) == [
-        2,
-        2,
-        1,
-        0,
-    ]
-    assert util.multiply_poly_poly_coeffmod([1, 2], [2, 3], 2, sealapi.Modulus(5), 4) == [
-        2,
-        2,
-        1,
-        0,
-    ]
-    assert util.multiply_truncate_poly_poly_coeffmod([1, 2], [2, 3], 2, sealapi.Modulus(5), 4) == [
-        2,
-        2,
-        0,
-        0,
-    ]
-    assert util.divide_poly_poly_coeffmod([4, 3], [2, 3], 2, sealapi.Modulus(5)) == [[1, 0], [2, 0]]
     assert util.dyadic_product_coeffmod([5, 7], [2, 3], 2, sealapi.Modulus(5), 4) == [0, 1, 0, 0]
     assert util.poly_infty_norm_coeffmod([5, 7], 2, sealapi.Modulus(5)) == 2
-    assert util.try_invert_poly_coeffmod([1, 0], [4, 3], 2, sealapi.Modulus(5)) == [1, 0]
     assert util.negacyclic_shift_poly_coeffmod([4, 3], 2, 1, sealapi.Modulus(5)) == [2, 4]
     assert util.negacyclic_multiply_poly_mono_coeffmod([4, 3], 2, 2, 1, sealapi.Modulus(5)) == [
         4,
         3,
     ]
-
-
-def test_util_polyarithmod():
-    assert util.negate_poly_coeffmod([1, 2], 2, [5], 1) == [4, 3]
-    assert util.add_poly_poly_coeffmod([1, 2], [2, 3], 2, [5], 1) == [3, 0]
-    assert util.add_poly_poly_coeffmod([3, 4], [2, 3], 2, [5], 1) == [0, 2]
-    assert util.poly_infty_norm_coeffmod([0, 1], 2, 1, [5]) == [1, 0]
 
 
 def test_util_polycore():
@@ -247,11 +208,8 @@ def test_util_ntt():
         coeff_count_power, sealapi.Modulus(util.get_prime(1 << coeff_count_power, 40))
     )
     assert tables.get_root() > 0
-    assert tables.get_from_root_powers(1) > 0
-    assert tables.get_from_scaled_root_powers(1) > 0
-    assert tables.get_from_inv_root_powers(1) > 0
-    assert tables.get_from_scaled_inv_root_powers(1) > 0
-    assert tables.get_inv_degree_modulo() > 0
+    assert tables.get_from_root_powers(1).operand > 0
+    assert tables.get_from_inv_root_powers(1).operand > 0
     assert tables.modulus() > 0
     assert tables.coeff_count_power() == coeff_count_power
     assert tables.coeff_count() == 1 << coeff_count_power


### PR DESCRIPTION
## Description
The versions of SEAL from 3.5.1 to 3.5.6 has [fixed many bugs and some optimizations](https://github.com/microsoft/SEAL/blob/master/CHANGES.md). This PR tried to upgrade SEAL from 3.5.1 to 3.5.6.
Then updated places are:
1. Since SEAL 3.5.6 removed `util/polyarith.h` and `util/polyarithmod.h`, removing related parts.
2. Updated some places related with `util/polyarithsmallmod.h` changes.
3. Updated some function call params using `ConstRNSIter` and `RNSIter` because of seal function param changes
4. Add `MultiplyUIntModOperand` python binding and update `coeff_div_plain_modulus` return type

## Affected Dependencies
SEAL lib

## How has this been tested?
pytest -v --ignore=tests/sealapi ./tests
cmake . -D BUILD_TEST=TRUE
make && CTEST_OUTPUT_ON_FAILURE=1 make test
pytest -v ./tests/sealapi

test cases under `tests` dir

## Checklist
- [Y ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [Y] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [Y] My changes are covered by tests
