### PR TITLE
Updated docker documentation, added .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,1 @@
 tutorials
-third_party

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+tutorials
+third_party

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,6 @@
 tutorials
+build
+bin
+dist
+lib
+wheels

--- a/README.md
+++ b/README.md
@@ -101,7 +101,13 @@ $ docker container run --interactive --tty openmined/tenseal
 You can also build your custom image, this might be handy for developers working on the project
 
 ```bash
-$ docker image build --tag tenseal .
+$ docker build -t tenseal . -f docker-images/Dockerfile-py38
+```
+
+To interactively run this docker image as a container after it has been built you can run
+
+```bash
+$ docker run -it tenseal
 ```
 
 ## Support

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ $ docker container run --interactive --tty openmined/tenseal
 You can also build your custom image, this might be handy for developers working on the project
 
 ```bash
-$ docker build -t tenseal . -f docker-images/Dockerfile-py38
+$ docker build -t tenseal -f docker-images/Dockerfile-py38 .
 ```
 
 To interactively run this docker image as a container after it has been built you can run


### PR DESCRIPTION

## Description

TLDR: Did not change much, just changed documentation to run docker properly and added .dockerignore for good practice.

.dockerignore is always important to have similarly to .gitignore to
keep in this case the docker context free from unecessary bloat.

Updated the documentation to correct the docker build and run invocation
so that it keep the existing style of using a subdirectory to store the
dockerfiles but puts the context in the current parent directory so the
files can be copied in properly.

## Affected Dependencies
None

## How has this been tested?
- Describe the tests that you ran to verify your changes.
ran the new commands
```
sudo docker build -t tenseal . -f docker-images/Dockerfile-py38
```
and 
```
sudo docker run -it tenseal
```
- Provide instructions so we can reproduce.
please run the above two commands or:
```
sudo docker build -t tenseal . -f docker-images/Dockerfile-py38 && sudo docker run -it tenseal
```
- List any relevant details for your test configuration.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
