### PR TITLE
Update docker tags

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -29,11 +29,17 @@ jobs:
       - name: docker login
         run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_LOGIN }} --password-stdin
 
-      - name: tag and push latest nightly images
+      - name: tag and push latest dev images
         if: github.event_name == 'push'
         run: |
-          docker tag $IMAGE $IMAGE:latest-py${{ matrix.python-version }}
-          docker push $IMAGE:latest-py${{ matrix.python-version }}
+          docker tag $IMAGE $IMAGE:dev-py${{ matrix.python-version }}
+          docker push $IMAGE:dev-py${{ matrix.python-version }}
+          
+      - name: push latest dev for python 3.8
+        if: github.event_name == 'push' && matrix.python-version == '38'
+        run: |
+          docker tag $IMAGE $IMAGE:dev
+          docker push $IMAGE:dev
 
       - name: tag and push release image
         if: github.event_name == 'release'

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ This installs the last packaged version on [pypi](https://pypi.org/project/tense
 
 Supported platforms and their requirements are listed below: (this are only required for building TenSEAL from source)
 - **Linux:** A modern version of GNU G++ (>= 6.0) or Clang++ (>= 5.0).
-- **macOS:** Xcode toolchain (>= 9.3)
+- **MacOS:** Xcode toolchain (>= 9.3)
 - **Windows:** Microsoft Visual Studio (>= 10.0.40219.1, Visual Studio 2010 SP1 or later).
 
 If you want to install tenseal from the repository, you should first make sure to have the requirements for your platform (listed above) and [CMake (3.12 or higher)](https://cmake.org/install/) installed, then get the third party libraries (if you didn't already) by running the following command from the root directory of the project
@@ -98,6 +98,9 @@ You can use our [Docker image](https://hub.docker.com/r/openmined/tenseal) for a
 $ docker container run --interactive --tty openmined/tenseal
 ```
 
+**Note:** `openmined/tenseal` points to the image from the last release, use `openmined/tenseal:dev` for the image built from the master branch.
+
+
 You can also build your custom image, this might be handy for developers working on the project
 
 ```bash
@@ -107,7 +110,7 @@ $ docker build -t tenseal -f docker-images/Dockerfile-py38 .
 To interactively run this docker image as a container after it has been built you can run
 
 ```bash
-$ docker run -it tenseal
+$ docker container run -it tenseal
 ```
 
 ## Support


### PR DESCRIPTION
## Description
To separate docker images for releases and those that follow the master branch, we now have release images for python different python version (e.g v0.1.0-pyXX), latest (latest release python 3.8), and dev for different python version (e.g dev-pyXX) with dev pointing to dev-py38.