### PR TITLE
Better handling of transparent ct exceptions

### DIFF
--- a/tenseal/tensors/bfvvector.cpp
+++ b/tenseal/tensors/bfvvector.cpp
@@ -212,9 +212,13 @@ BFVVector& BFVVector::mul_plain_inplace(const vector<int64_t>& to_mul) {
     try {
         this->tenseal_context()->evaluator->multiply_plain_inplace(
             this->ciphertext, plaintext);
-    } catch (const std::logic_error& e) {  // result ciphertext is transparent
-        // replace by encryption of zero
-        this->tenseal_context()->encryptor->encrypt_zero(this->ciphertext);
+    } catch (const std::logic_error& e) {
+        if (e.what() == "result ciphertext is transparent") {
+            // replace by encryption of zero
+            this->tenseal_context()->encryptor->encrypt_zero(this->ciphertext);
+        } else {  // Something else, need to be forwarded
+            throw;
+        }
     }
 
     return *this;

--- a/tenseal/tensors/bfvvector.cpp
+++ b/tenseal/tensors/bfvvector.cpp
@@ -213,7 +213,7 @@ BFVVector& BFVVector::mul_plain_inplace(const vector<int64_t>& to_mul) {
         this->tenseal_context()->evaluator->multiply_plain_inplace(
             this->ciphertext, plaintext);
     } catch (const std::logic_error& e) {
-        if (e.what() == "result ciphertext is transparent") {
+        if (strcmp(e.what(), "result ciphertext is transparent") == 0) {
             // replace by encryption of zero
             this->tenseal_context()->encryptor->encrypt_zero(this->ciphertext);
         } else {  // Something else, need to be forwarded

--- a/tenseal/tensors/ckksvector.cpp
+++ b/tenseal/tensors/ckksvector.cpp
@@ -404,12 +404,15 @@ CKKSVector& CKKSVector::_mul_plain_inplace(const T& to_mul) {
     try {
         this->tenseal_context()->evaluator->multiply_plain_inplace(
             this->ciphertext, plaintext);
-    } catch (const std::logic_error& e) {  // result ciphertext is transparent
-        // TODO: chech if error e is exactly a "ciphertext is transparent" error
-        // replace by encryption of zero
-        this->tenseal_context()->encryptor->encrypt_zero(this->ciphertext);
-        this->ciphertext.scale() = this->init_scale;
-        return *this;
+    } catch (const std::logic_error& e) {
+        if (e.what() == "result ciphertext is transparent") {
+            // replace by encryption of zero
+            this->tenseal_context()->encryptor->encrypt_zero(this->ciphertext);
+            this->ciphertext.scale() = this->init_scale;
+            return *this;
+        } else {  // Something else, need to be forwarded
+            throw;
+        }
     }
 
     if (this->tenseal_context()->auto_rescale()) {

--- a/tenseal/tensors/ckksvector.cpp
+++ b/tenseal/tensors/ckksvector.cpp
@@ -405,7 +405,7 @@ CKKSVector& CKKSVector::_mul_plain_inplace(const T& to_mul) {
         this->tenseal_context()->evaluator->multiply_plain_inplace(
             this->ciphertext, plaintext);
     } catch (const std::logic_error& e) {
-        if (e.what() == "result ciphertext is transparent") {
+        if (strcmp(e.what(), "result ciphertext is transparent") == 0) {
             // replace by encryption of zero
             this->tenseal_context()->encryptor->encrypt_zero(this->ciphertext);
             this->ciphertext.scale() = this->init_scale;


### PR DESCRIPTION
## Description
Before we were handling all logic_error exception, which included exceptions we didn't won't to catch (e.g. scale out of bound), so here we check the error message to only handle *transparent ciphertexts* exceptions and forward the rest.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
