### PR TITLE
fix CKKS and BFV vectors constructors

### DIFF
--- a/tenseal/cpp/tensors/bfvvector.cpp
+++ b/tenseal/cpp/tensors/bfvvector.cpp
@@ -16,7 +16,7 @@ namespace tenseal {
 BFVVector::BFVVector(shared_ptr<TenSEALContext> ctx, vector<int64_t> vec) {
     this->link_tenseal_context(ctx);
     // Encrypts the whole vector into a single ciphertext using BFV batching
-    this->ciphertext = BFVVector::encrypt(context, vec);
+    this->ciphertext = BFVVector::encrypt(ctx, vec);
     this->_size = vec.size();
 }
 

--- a/tenseal/cpp/tensors/ckksvector.cpp
+++ b/tenseal/cpp/tensors/ckksvector.cpp
@@ -23,11 +23,11 @@ CKKSVector::CKKSVector(shared_ptr<TenSEALContext> ctx, vector<double> vec,
     if (scale.has_value()) {
         this->init_scale = scale.value();
     } else {
-        this->init_scale = context->global_scale();
+        this->init_scale = ctx->global_scale();
     }
 
     // Encrypts the whole vector into a single ciphertext using CKKS batching
-    this->ciphertext = CKKSVector::encrypt(context, init_scale, vec);
+    this->ciphertext = CKKSVector::encrypt(ctx, init_scale, vec);
     this->_size = vec.size();
 }
 


### PR DESCRIPTION
## Description
- Fix small mistake in CKKS and BFV vector constructor code.
- The code was working just fine, because of linking tenseal context before setting `init_scale` and doing encryption, as a result `context` variable was resolved as `this->context`.