### PR TITLE
Encrypted matrix multiplication with plain vector

### DIFF
--- a/tenseal/__init__.py
+++ b/tenseal/__init__.py
@@ -18,6 +18,7 @@ GaloisKeys = _ts_cpp.GaloisKeys
 
 # utils
 im2col_encoding = _ts_cpp.im2col_encoding
+enc_matmul_encoding = _ts_cpp.enc_matmul_encoding
 
 
 def context(

--- a/tenseal/cpp/tensors/ckksvector.cpp
+++ b/tenseal/cpp/tensors/ckksvector.cpp
@@ -587,63 +587,19 @@ CKKSVector& CKKSVector::conv2d_im2col_inplace(
     vector<double> flatten_kernel;
     horizontal_scan(kernel, flatten_kernel);
 
-    // calculate the next power of 2
-    size_t kernel_size = kernel.size() * kernel[0].size();
-    kernel_size = 1 << (static_cast<size_t>(ceil(log2(kernel_size))));
-
-    // pad the kernel with zeros to the next power of 2
-    flatten_kernel.resize(kernel_size, 0);
-
-    size_t chunks_nb = flatten_kernel.size();
-
-    if (this->_size / windows_nb != chunks_nb) {
-        throw invalid_argument("Matrix shape doesn't match with vector size");
-    }
-
-    vector<double> plain_vec;
-    plain_vec.reserve(this->_size);
-
-    for (size_t i = 0; i < chunks_nb; i++) {
-        vector<double> tmp(windows_nb, flatten_kernel[i]);
-        plain_vec.insert(plain_vec.end(), tmp.begin(), tmp.end());
-    }
-
-    // replicate the vector in order to be able to do multiple matrix
-    // multiplications
-    size_t slot_count = this->context->slot_count<CKKSEncoder>();
-    replicate_vector(plain_vec, slot_count);
-    this->_size = slot_count;
-
-    this->mul_plain_inplace(plain_vec);
-
-    auto galois_keys = this->context->galois_keys();
-
-    CKKSVector tmp = *this;
-
-    while (chunks_nb > 1) {
-        tmp = *this;
-        chunks_nb = static_cast<int>(
-            1 << (static_cast<size_t>(ceil(log2(chunks_nb))) - 1));
-        this->context->evaluator->rotate_vector_inplace(
-            tmp.ciphertext, static_cast<int>(windows_nb * chunks_nb),
-            *galois_keys);
-        this->add_inplace(tmp);
-    }
-
-    this->_size = windows_nb;
-
+    this->enc_matmul_plain_inplace(flatten_kernel, windows_nb);
     return *this;
 }
 
 CKKSVector CKKSVector::enc_matmul_plain(const vector<double>& plain_vec,
-                                        size_t rows_nb) {
+                                        const size_t rows_nb) {
     CKKSVector new_vec = *this;
     new_vec.enc_matmul_plain_inplace(plain_vec, rows_nb);
     return new_vec;
 }
 
 CKKSVector& CKKSVector::enc_matmul_plain_inplace(
-    const vector<double>& plain_vec, size_t rows_nb) {
+    const vector<double>& plain_vec, const size_t rows_nb) {
     if (plain_vec.empty()) {
         throw invalid_argument("Plain vector can't be empty");
     }

--- a/tenseal/cpp/tensors/ckksvector.h
+++ b/tenseal/cpp/tensors/ckksvector.h
@@ -108,12 +108,20 @@ class CKKSVector {
     CKKSVector& sum_inplace();
 
     /**
-     * Matrix multiplication operations.
+     * Encrypted Vector multiplication with plain matrix.
      **/
     CKKSVector matmul_plain(const vector<vector<double>>& matrix,
                             size_t n_jobs = 0);
     CKKSVector& matmul_plain_inplace(const vector<vector<double>>& matrix,
                                      size_t n_jobs = 0);
+
+    /**
+     * Encrypted Matrix multiplication with plain vector.
+     **/
+    CKKSVector enc_matmul_plain(const vector<double>& plain_vec,
+                                size_t row_size);
+    CKKSVector& enc_matmul_plain_inplace(const vector<double>& plain_vec,
+                                         size_t row_size);
 
     /**
      * Polynomial evaluation with `this` as variable.

--- a/tests/python/tenseal/tensors/test_ckks_vector.py
+++ b/tests/python/tenseal/tensors/test_ckks_vector.py
@@ -1009,6 +1009,29 @@ def test_vec_plain_matrix_mul_depth2(context, vec, matrix1, matrix2, precision):
 
 
 @pytest.mark.parametrize(
+    "matrix_shape, vector_size",
+    [((1, 1), 1), ((2, 1), 1), ((3, 2), 2), ((4, 4), 4), ((9, 7), 7), ((16, 12), 12),],
+)
+def test_enc_matmul_plain(context, matrix_shape, vector_size, precision):
+    def generate_input(matrix_shape, vector_size):
+        # generated random values
+        matrix = np.random.randn(*matrix_shape)
+        vector = np.random.randn(vector_size)
+
+        return matrix, vector
+
+    matrix, vector = generate_input(matrix_shape, vector_size)
+    expected = matrix @ vector
+
+    context.generate_galois_keys()
+    ckks_vector = ts.enc_matmul_encoding(context, matrix.tolist())
+    result = ckks_vector.enc_matmul_plain(vector.tolist(), matrix_shape[0])
+    assert _almost_equal(
+        result.decrypt(), expected, precision
+    ), "Matrix multiplication is incorrect."
+
+
+@pytest.mark.parametrize(
     "data, polynom",
     [
         # null polynom


### PR DESCRIPTION
## Description
- Introduce Encrypted matrix multiplication with plain vector.
- The matrix should be padded with zeros (each row size need to be a power of two).
- The matrix should be encoded into a CKKS vector with vertical scan (column major).
- The matrix multiplication assumes that the matrix is encoded as I mentioned above, the plain vector should be also padded with zeros to the next power of two.
- There's a helper function to pad and encode the matrix, the resulting CKKS vector can do only `Encrypted matrix multiplication with plain vector` operation, but the result of this operation is a regular CKKS vector.

## Affected Dependencies
- None.

## How has this been tested?
- Python tests with random values generated using numpy.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests

## TODO
- find a better name for functions.
