### PR TITLE
Fix python binding for conv2d_im2col and enc_matmul_plain

### DIFF
--- a/tenseal/binding.cpp
+++ b/tenseal/binding.cpp
@@ -179,9 +179,9 @@ PYBIND11_MODULE(_tenseal_cpp, m) {
         .def("mm_", &CKKSVector::matmul_plain_inplace, py::arg("matrix"),
              py::arg("n_jobs") = 0)
         .def("conv2d_im2col", &CKKSVector::conv2d_im2col)
-        .def("conv2d_im2col_inplace", &CKKSVector::conv2d_im2col_inplace)
+        .def("conv2d_im2col_", &CKKSVector::conv2d_im2col_inplace)
         .def("enc_matmul_plain", &CKKSVector::enc_matmul_plain)
-        .def("enc_matmul_plain_inplace", &CKKSVector::enc_matmul_plain)
+        .def("enc_matmul_plain_", &CKKSVector::enc_matmul_plain_inplace)
         // python arithmetic
         .def("__neg__", &CKKSVector::negate)
         .def("__pow__", &CKKSVector::power)


### PR DESCRIPTION
## Description
Fix python binding for `conv2d_im2col` and `enc_matmul_plain`.

## Affected Dependencies
None.

## How has this been tested?
- Python tests.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
