### PR TITLE
Vectors packing

### DIFF
--- a/tenseal/__init__.py
+++ b/tenseal/__init__.py
@@ -19,6 +19,7 @@ GaloisKeys = _ts_cpp.GaloisKeys
 # utils
 im2col_encoding = _ts_cpp.im2col_encoding
 enc_matmul_encoding = _ts_cpp.enc_matmul_encoding
+pack_vectors = _ts_cpp.pack_vectors
 
 
 def context(

--- a/tenseal/binding.cpp
+++ b/tenseal/binding.cpp
@@ -117,6 +117,9 @@ PYBIND11_MODULE(_tenseal_cpp, m) {
         return ckks_vector;
     });
 
+    m.def("pack_vectors", &pack_vectors<CKKSVector, CKKSEncoder, double>);
+    m.def("pack_vectors", &pack_vectors<BFVVector, BatchEncoder, int64_t>);
+
     py::class_<CKKSVector>(m, "CKKSVector")
         // specifying scale
         .def(py::init<shared_ptr<TenSEALContext> &, vector<double>, double>())

--- a/tenseal/cpp/tensors/bfvvector.h
+++ b/tenseal/cpp/tensors/bfvvector.h
@@ -7,6 +7,7 @@
 
 #include "seal/seal.h"
 #include "tenseal/cpp/context/tensealcontext.h"
+#include "tenseal/cpp/tensors/utils/utils.h"
 #include "tenseal/proto/tensors.pb.h"
 
 namespace tenseal {
@@ -117,6 +118,11 @@ class BFVVector {
     BFVVectorProto save_proto() const;
 
     void load_context_proto(const TenSEALContextProto& buffer);
+
+    // make pack_vectors a friend function in order to be able to modify vector
+    // size (_size private member)
+    friend BFVVector pack_vectors<BFVVector, BatchEncoder, int64_t>(
+        vector<BFVVector>&);
 };
 
 }  // namespace tenseal

--- a/tenseal/cpp/tensors/ckksvector.h
+++ b/tenseal/cpp/tensors/ckksvector.h
@@ -208,6 +208,11 @@ class CKKSVector {
     CKKSVectorProto save_proto() const;
 
     void load_context_proto(const TenSEALContextProto& buffer);
+
+    // make pack_vectors a friend function in order to be able to modify vector
+    // size (_size private member)
+    friend CKKSVector pack_vectors<CKKSVector, CKKSEncoder, double>(
+        vector<CKKSVector>&);
 };
 
 }  // namespace tenseal

--- a/tenseal/cpp/tensors/utils/utils.h
+++ b/tenseal/cpp/tensors/utils/utils.h
@@ -195,7 +195,7 @@ T compute_polynomial_term(int degree, double coeff,
     return x;
 }
 
-// TODO: use const for argument
+// TODO: use const for vectors argument after merging code-optimazation branche
 template <typename T, class Encoder, typename D>
 T pack_vectors(vector<T>& vectors) {
     size_t vectors_nb = vectors.size();

--- a/tenseal/cpp/tensors/utils/utils.h
+++ b/tenseal/cpp/tensors/utils/utils.h
@@ -195,40 +195,49 @@ T compute_polynomial_term(int degree, double coeff,
     return x;
 }
 
-template <typename T, class Encoder>
-T pack_vectors(const vector<T>& vectors) {
+// TODO: use const for argument
+template <typename T, class Encoder, typename D>
+T pack_vectors(vector<T>& vectors) {
     size_t vectors_nb = vectors.size();
     size_t vector_size = vectors[0].size();
-    size_t slot_count = vectors[0].context->slot_count<Encoder>();
+    size_t output_size = vectors_nb * vector_size;
+    size_t mask_shift = output_size - vector_size;
+    size_t slot_count =
+        vectors[0].tenseal_context()->template slot_count<Encoder>();
 
     // check if each vectors sizes are equal
     if (any_of(vectors.begin(), vectors.end(),
-               [vector_size](const vector<T>& i) {
-                   return i.size() != vector_size;
-               })) {
+               [vector_size](T& i) { return i.size() != vector_size; })) {
         throw invalid_argument("vectors sizes are different");
     }
 
     // mask vector to multiply with ciphertext
-    vector<int> mask(vectors_nb * vector_size, 0);
-    fill(mask.begin(), mask.beging() + vector_size, 1);
+    vector<D> mask(vectors_nb * vector_size, 0);
+    fill(mask.begin(), mask.begin() + vector_size, 1);
 
     // copy and replicate mask vector
-    vector<int> replicated_mask = mask;
+    vector<D> replicated_mask = mask;
     replicate_vector(replicated_mask, slot_count);
 
-    T packed_vec = vectors[0].mul_plain(replicated_mask);
+    T packed_vec = vectors[0];
+    packed_vec._size = slot_count;
+    packed_vec.mul_plain_inplace(replicated_mask);
 
     for (size_t i = 1; i < vectors_nb; i++) {
-        replicated_mask = mask;
         // rotate the mask then replicate it
-        rotate(replicated_mask.begin(), replicated_mask.begin() + vector_size,
-               replicated_mask.end());
+        rotate(mask.begin(), mask.begin() + mask_shift, mask.end());
+        replicated_mask = mask;
         replicate_vector(replicated_mask, slot_count);
 
         // multiply with the mask vector then accumulate
-        packed_vec.add_inplace(vectors[i].mul_plain(replicated_mask));
+        T vec = vectors[i];
+        vec._size = slot_count;
+        vec.mul_plain_inplace(replicated_mask);
+        packed_vec.add_inplace(vec);
     }
+
+    // set packed vector size to the total size of vectors
+    packed_vec._size = output_size;
 
     return packed_vec;
 }

--- a/tests/python/tenseal/test_utils.py
+++ b/tests/python/tenseal/test_utils.py
@@ -1,0 +1,46 @@
+from functools import reduce
+
+import pytest
+import numpy as np
+
+import tenseal as ts
+
+from tests.python.tenseal.utils import *
+
+
+@pytest.mark.parametrize("vectors_nb", [1, 2, 3, 4, 9])
+@pytest.mark.parametrize("vector_size", [1, 3, 11, 16, 64])
+def test_pack_ckks_vectors(vectors_nb, vector_size):
+    context = ts.context(ts.SCHEME_TYPE.CKKS, 8192, coeff_mod_bit_sizes=[60, 40, 40, 60])
+    context.global_scale = pow(2, 40)
+    # generated galois keys in order to do rotation on ciphertext vectors
+    context.generate_galois_keys()
+
+    # generate vectors
+    vectors = [np.random.randn(vector_size).tolist() for _ in range(vectors_nb)]
+
+    enc_vectors = list(map(lambda v: ts.ckks_vector(context, v), vectors))
+
+    result = ts.pack_vectors(enc_vectors)
+    expected = reduce(lambda x, y: x + y, vectors, [])
+
+    assert almost_equal(result.decrypt(), expected, 1), "packing CKKS vectors is incorrect."
+
+
+@pytest.mark.parametrize("vectors_nb", [1, 2, 3, 4, 9])
+@pytest.mark.parametrize("vector_size", [1, 3, 11, 16, 64])
+def test_pack_bfv_vectors(vectors_nb, vector_size):
+    context = ts.context(ts.SCHEME_TYPE.BFV, 8192, 1032193)
+    # generated galois keys in order to do rotation on ciphertext vectors
+    context.generate_galois_keys()
+
+    # generate vectors
+    vectors = [np.random.randint(1000, size=vector_size).tolist() for _ in range(vectors_nb)]
+
+    enc_vectors = list(map(lambda v: ts.bfv_vector(context, v), vectors))
+
+    packed_vec = ts.pack_vectors(enc_vectors)
+    result = packed_vec.decrypt()
+    expected = reduce(lambda x, y: x + y, vectors, [])
+
+    assert almost_equal(result, expected, 1), "packing BFV vectors is incorrect."


### PR DESCRIPTION
## Description
This PR introduce a new function that allow packing multiple vectors (both CKKS and BFV) into a single vector. This will allow to pack multiple convolutions channels into a single vector then pass them to the next layer.

**PS:**
The tests will fail because BFV vector isn't replicating the input plaintext vector before encoding, it will be fixed in #140.
So after merging #140 the tests will pass.

## Affected Dependencies
None.

## How has this been tested?
- Python tests.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
