### PR TITLE
race condition for multithreaded exceptions

### DIFF
--- a/tenseal/cpp/utils/queue.h
+++ b/tenseal/cpp/utils/queue.h
@@ -1,7 +1,6 @@
 #ifndef TENSEAL_UTILS_QUEUE_H
 #define TENSEAL_UTILS_QUEUE_H
 
-#include <atomic>
 #include <cassert>
 #include <chrono>
 #include <condition_variable>

--- a/tests/python/tenseal/BUILD
+++ b/tests/python/tenseal/BUILD
@@ -12,6 +12,7 @@ py_test(
         "tensors/test_ckks_vector.py",
         "tensors/test_perf.py",
         "tensors/test_serialization.py",
+        "tensors/test_regression.py",
             ],
     main = "main.py",
     python_version = "PY3",

--- a/tests/python/tenseal/tensors/test_regression.py
+++ b/tests/python/tenseal/tensors/test_regression.py
@@ -1,0 +1,16 @@
+import sys, os
+import pytest
+import tenseal as ts
+
+
+def test_matmul_scale_bounds():
+    N_THREADS = 8
+    ctx = ts.context(ts.SCHEME_TYPE.CKKS, 8192, -1, [60, 40, 60], n_threads=N_THREADS)
+    ctx.global_scale = 2 ** 40
+    ctx.generate_galois_keys()
+
+    vec = ts.ckks_vector(ctx, [0, 1])
+    vec.square_()
+
+    with pytest.raises(ValueError) as e:
+        vec.mm_([[1, 2], [3, 4]])


### PR DESCRIPTION
## Description

In the multi-threaded setup, if one of the workers threw an exception, we didn't wait for the rest of the threads to finish/fail.
This resulted in a crash instead of an exception.

fixes https://github.com/OpenMined/TenSEAL/issues/150


## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
