### PR TITLE
CKKS Tensor

### DIFF
--- a/.github/workflows/pythonpublish-windows.yml
+++ b/.github/workflows/pythonpublish-windows.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install dependencies
         run: .github/workflows/scripts/install_req_windows.bat
       - name: Setup msbuild
-        uses: microsoft/setup-msbuild@v1.0.0
+        uses: microsoft/setup-msbuild@v1.0.2
       - name: Build and publish
         env:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,7 +65,7 @@ jobs:
         run: .github/workflows/scripts/install_req_windows.bat
         if: ${{ matrix.os == 'windows-latest' }}
       - name: Install dependencies Windows - msbuild
-        uses: microsoft/setup-msbuild@v1.0.0
+        uses: microsoft/setup-msbuild@v1.0.2
         if: ${{ matrix.os == 'windows-latest' }}
       - name: Build the library for Ubuntu/MacOS
         run: .github/workflows/scripts/build_nix.sh
@@ -106,7 +106,7 @@ jobs:
         run: .github/workflows/scripts/install_req_windows.bat
         if: ${{ matrix.os == 'windows-latest' }}
       - name: Install dependencies Windows - msbuild
-        uses: microsoft/setup-msbuild@v1.0.0
+        uses: microsoft/setup-msbuild@v1.0.2
         if: ${{ matrix.os == 'windows-latest' }}
       - name: Build the library for Ubuntu/MacOS
         run: .github/workflows/scripts/build_nix.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ set(SOURCES
     ${TENSEAL_BASEDIR}/cpp/context/tensealcontext.cpp
     ${TENSEAL_BASEDIR}/cpp/context/sealcontext.cpp
     ${TENSEAL_BASEDIR}/cpp/tensors/bfvvector.cpp
+    ${TENSEAL_BASEDIR}/cpp/tensors/ckkstensor.cpp
     ${TENSEAL_BASEDIR}/cpp/tensors/ckksvector.cpp
     ${TENSEAL_BASEDIR}/cpp/tensors/utils/utils.cpp)
 if(WIN32)

--- a/tenseal/__init__.py
+++ b/tenseal/__init__.py
@@ -6,7 +6,7 @@ try:
 except ImportError:
     import tenseal._tenseal_cpp as _ts_cpp
 
-from tenseal.tensors import bfv_vector, bfv_vector_from, ckks_vector, ckks_vector_from
+from tenseal.tensors import bfv_vector, bfv_vector_from, ckks_vector, ckks_vector_from, ckks_tensor, plain_tensor
 from tenseal.version import __version__
 
 

--- a/tenseal/__init__.py
+++ b/tenseal/__init__.py
@@ -6,7 +6,14 @@ try:
 except ImportError:
     import tenseal._tenseal_cpp as _ts_cpp
 
-from tenseal.tensors import bfv_vector, bfv_vector_from, ckks_vector, ckks_vector_from, ckks_tensor, plain_tensor
+from tenseal.tensors import (
+    bfv_vector,
+    bfv_vector_from,
+    ckks_vector,
+    ckks_vector_from,
+    ckks_tensor,
+    plain_tensor,
+)
 from tenseal.version import __version__
 
 

--- a/tenseal/binding.cpp
+++ b/tenseal/binding.cpp
@@ -440,7 +440,12 @@ PYBIND11_MODULE(_tenseal_cpp, m) {
                          const PlainTensor<double> &tensor) {
             return CKKSTensor::Create(ctx, tensor);
         }))
-        .def("decrypt", py::overload_cast<>(&CKKSTensor::decrypt, py::const_));
+        .def("decrypt", [](shared_ptr<CKKSTensor> obj){
+            return obj->decrypt().data();
+        })
+        .def("decrypt", [](shared_ptr<CKKSTensor> obj, const shared_ptr<SecretKey> &sk){
+            return obj->decrypt(sk).data();
+        });
 
     py::class_<TenSEALContext, std::shared_ptr<TenSEALContext>>(
         m, "TenSEALContext")

--- a/tenseal/binding.cpp
+++ b/tenseal/binding.cpp
@@ -440,12 +440,12 @@ PYBIND11_MODULE(_tenseal_cpp, m) {
                          const PlainTensor<double> &tensor) {
             return CKKSTensor::Create(ctx, tensor);
         }))
-        .def("decrypt", [](shared_ptr<CKKSTensor> obj){
-            return obj->decrypt().data();
-        })
-        .def("decrypt", [](shared_ptr<CKKSTensor> obj, const shared_ptr<SecretKey> &sk){
-            return obj->decrypt(sk).data();
-        });
+        .def("decrypt",
+             [](shared_ptr<CKKSTensor> obj) { return obj->decrypt().data(); })
+        .def("decrypt",
+             [](shared_ptr<CKKSTensor> obj, const shared_ptr<SecretKey> &sk) {
+                 return obj->decrypt(sk).data();
+             });
 
     py::class_<TenSEALContext, std::shared_ptr<TenSEALContext>>(
         m, "TenSEALContext")

--- a/tenseal/binding.cpp
+++ b/tenseal/binding.cpp
@@ -430,6 +430,18 @@ PYBIND11_MODULE(_tenseal_cpp, m) {
                 return pack_vectors<CKKSVector, CKKSEncoder, double>(vectors);
             });
 
+    py::class_<CKKSTensor, std::shared_ptr<CKKSTensor>>(m, "CKKSTensor",
+                                                        py::module_local())
+        .def(py::init([](const shared_ptr<TenSEALContext> &ctx,
+                         const PlainTensor<double> &tensor, double scale) {
+            return CKKSTensor::Create(ctx, tensor, scale);
+        }))
+        .def(py::init([](const shared_ptr<TenSEALContext> &ctx,
+                         const PlainTensor<double> &tensor) {
+            return CKKSTensor::Create(ctx, tensor);
+        }))
+        .def("decrypt", py::overload_cast<>(&CKKSTensor::decrypt, py::const_));
+
     py::class_<TenSEALContext, std::shared_ptr<TenSEALContext>>(
         m, "TenSEALContext")
         .def_property(

--- a/tenseal/cpp/tensors/BUILD
+++ b/tenseal/cpp/tensors/BUILD
@@ -9,6 +9,7 @@ cc_library(
     srcs = [
         "bfvvector.cpp",
         "ckksvector.cpp",
+        "ckkstensor.cpp",
         "utils/utils.cpp",
         "utils/utils.h",
     ],
@@ -16,6 +17,7 @@ cc_library(
         "api.h",
         "bfvvector.h",
         "ckksvector.h",
+        "ckkstensor.h",
         "encrypted_tensor.h",
         "encrypted_vector.h",
         "plain_tensor.h",

--- a/tenseal/cpp/tensors/api.h
+++ b/tenseal/cpp/tensors/api.h
@@ -2,6 +2,7 @@
 #define TENSEAL_TENSOR_API_H
 
 #include "tenseal/cpp/tensors/bfvvector.h"
+#include "tenseal/cpp/tensors/ckkstensor.h"
 #include "tenseal/cpp/tensors/ckksvector.h"
 #include "tenseal/cpp/tensors/encrypted_tensor.h"
 #include "tenseal/cpp/tensors/encrypted_vector.h"

--- a/tenseal/cpp/tensors/ckkstensor.cpp
+++ b/tenseal/cpp/tensors/ckkstensor.cpp
@@ -1,0 +1,47 @@
+#include "tenseal/cpp/tensors/ckkstensor.h"
+
+using namespace seal;
+using namespace std;
+
+namespace tenseal {
+
+CKKSTensor::CKKSTensor(const shared_ptr<TenSEALContext>& ctx,
+                       const vector<double>& data, std::optional<double> scale)
+    : _shape({data.size()}), _strides({1}) {
+    this->link_tenseal_context(ctx);
+    if (scale.has_value()) {
+        this->_init_scale = scale.value();
+    } else {
+        this->_init_scale = ctx->global_scale();
+    }
+
+    for (int i = 0; i < data.size(); i++)
+        _data.push_back(CKKSTensor::encrypt(ctx, this->_init_scale, data[i]));
+}
+
+Ciphertext CKKSTensor::encrypt(const shared_ptr<TenSEALContext>& ctx,
+                               const double scale, const double data) {
+    return encrypt(ctx, scale, {data});
+}
+
+Ciphertext CKKSTensor::encrypt(const shared_ptr<TenSEALContext>& ctx,
+                               const double scale, const vector<double>& data) {
+    if (data.empty()) {
+        throw invalid_argument("Attempting to encrypt an empty vector");
+    }
+    auto slot_count = ctx->slot_count<CKKSEncoder>();
+    if (data.size() > slot_count)
+        // number of slots available is poly_modulus_degree / 2
+        throw invalid_argument(
+            "can't encrypt vectors of this size, please use a larger "
+            "polynomial modulus degree.");
+
+    Ciphertext ciphertext(ctx->seal_context());
+    Plaintext plaintext;
+    ctx->encode<CKKSEncoder>(data, plaintext, scale);
+    ctx->encryptor->encrypt(plaintext, ciphertext);
+
+    return ciphertext;
+}
+
+}  // namespace tenseal

--- a/tenseal/cpp/tensors/ckkstensor.cpp
+++ b/tenseal/cpp/tensors/ckkstensor.cpp
@@ -176,10 +176,12 @@ string CKKSTensor::save() const {
 
 shared_ptr<CKKSTensor> CKKSTensor::copy() const {
     // TODO
+    return nullptr;
 }
 
 shared_ptr<CKKSTensor> CKKSTensor::deepcopy() const {
     // TODO
+    return nullptr;
 }
 
 }  // namespace tenseal

--- a/tenseal/cpp/tensors/ckkstensor.cpp
+++ b/tenseal/cpp/tensors/ckkstensor.cpp
@@ -18,13 +18,8 @@ CKKSTensor::CKKSTensor(const shared_ptr<TenSEALContext>& ctx,
 
     vector<double> plain_data = tensor.data();
     for (int i = 0; i < plain_data.size(); i++)
-        _data.push_back(
-            CKKSTensor::encrypt(ctx, this->_init_scale, plain_data[i]));
-}
-
-Ciphertext CKKSTensor::encrypt(const shared_ptr<TenSEALContext>& ctx,
-                               const double scale, const double data) {
-    return encrypt(ctx, scale, vector<double>({data}));
+        _data.push_back(CKKSTensor::encrypt(ctx, this->_init_scale,
+                                            vector<double>({plain_data[i]})));
 }
 
 Ciphertext CKKSTensor::encrypt(const shared_ptr<TenSEALContext>& ctx,

--- a/tenseal/cpp/tensors/ckkstensor.cpp
+++ b/tenseal/cpp/tensors/ckkstensor.cpp
@@ -1,13 +1,14 @@
 #include "tenseal/cpp/tensors/ckkstensor.h"
 
+namespace tenseal {
+
 using namespace seal;
 using namespace std;
 
-namespace tenseal {
-
 CKKSTensor::CKKSTensor(const shared_ptr<TenSEALContext>& ctx,
-                       const vector<double>& data, std::optional<double> scale)
-    : _shape({data.size()}), _strides({1}) {
+                       const PlainTensor<double>& tensor,
+                       std::optional<double> scale)
+    : _shape(tensor.shape()), _strides(tensor.strides()) {
     this->link_tenseal_context(ctx);
     if (scale.has_value()) {
         this->_init_scale = scale.value();
@@ -15,13 +16,15 @@ CKKSTensor::CKKSTensor(const shared_ptr<TenSEALContext>& ctx,
         this->_init_scale = ctx->global_scale();
     }
 
-    for (int i = 0; i < data.size(); i++)
-        _data.push_back(CKKSTensor::encrypt(ctx, this->_init_scale, data[i]));
+    vector<double> plain_data = tensor.data();
+    for (int i = 0; i < plain_data.size(); i++)
+        _data.push_back(
+            CKKSTensor::encrypt(ctx, this->_init_scale, plain_data[i]));
 }
 
 Ciphertext CKKSTensor::encrypt(const shared_ptr<TenSEALContext>& ctx,
                                const double scale, const double data) {
-    return encrypt(ctx, scale, {data});
+    return encrypt(ctx, scale, vector<double>({data}));
 }
 
 Ciphertext CKKSTensor::encrypt(const shared_ptr<TenSEALContext>& ctx,
@@ -42,6 +45,141 @@ Ciphertext CKKSTensor::encrypt(const shared_ptr<TenSEALContext>& ctx,
     ctx->encryptor->encrypt(plaintext, ciphertext);
 
     return ciphertext;
+}
+
+PlainTensor<double> CKKSTensor::decrypt() const {
+    if (this->tenseal_context()->decryptor == NULL) {
+        // this->context was loaded with public keys only
+        throw invalid_argument(
+            "the current context of the tensor doesn't hold a secret_key, "
+            "please provide one as argument");
+    }
+
+    return this->decrypt(this->tenseal_context()->secret_key());
+}
+
+PlainTensor<double> CKKSTensor::decrypt(const shared_ptr<SecretKey>& sk) const {
+    Plaintext plaintext;
+    Decryptor decryptor =
+        Decryptor(this->tenseal_context()->seal_context(), *sk);
+
+    vector<double> result;
+    vector<double> buff;
+    result.reserve(this->_data.size());
+
+    for (size_t i = 0; i < this->_data.size(); i++) {
+        decryptor.decrypt(this->_data[i], plaintext);
+        this->tenseal_context()->decode<CKKSEncoder>(plaintext, buff);
+        result.push_back(buff[0]);
+    }
+
+    return result;
+}
+
+shared_ptr<CKKSTensor> CKKSTensor::negate_inplace() {
+    // TODO
+    return shared_from_this();
+}
+
+shared_ptr<CKKSTensor> CKKSTensor::square_inplace() {
+    // TODO
+    return shared_from_this();
+}
+
+shared_ptr<CKKSTensor> CKKSTensor::power_inplace(unsigned int power) {
+    // TODO
+    return shared_from_this();
+}
+
+shared_ptr<CKKSTensor> CKKSTensor::add_inplace(
+    const shared_ptr<CKKSTensor>& to_add) {
+    // TODO
+    return shared_from_this();
+}
+
+shared_ptr<CKKSTensor> CKKSTensor::sub_inplace(
+    const shared_ptr<CKKSTensor>& to_sub) {
+    // TODO
+    return shared_from_this();
+}
+
+shared_ptr<CKKSTensor> CKKSTensor::mul_inplace(
+    const shared_ptr<CKKSTensor>& to_mul) {
+    // TODO
+    return shared_from_this();
+}
+
+shared_ptr<CKKSTensor> CKKSTensor::dot_product_inplace(
+    const shared_ptr<CKKSTensor>& to_mul) {
+    // TODO
+    return shared_from_this();
+}
+
+shared_ptr<CKKSTensor> CKKSTensor::add_plain_inplace(
+    const PlainTensor<double>& to_add) {
+    // TODO
+    return shared_from_this();
+}
+
+shared_ptr<CKKSTensor> CKKSTensor::sub_plain_inplace(
+    const PlainTensor<double>& to_sub) {
+    // TODO
+    return shared_from_this();
+}
+
+shared_ptr<CKKSTensor> CKKSTensor::mul_plain_inplace(
+    const PlainTensor<double>& to_mul) {
+    // TODO
+    return shared_from_this();
+}
+
+shared_ptr<CKKSTensor> CKKSTensor::dot_product_plain_inplace(
+    const PlainTensor<double>& to_mul) {
+    // TODO
+    return shared_from_this();
+}
+
+shared_ptr<CKKSTensor> CKKSTensor::add_plain_inplace(const double& to_add) {
+    // TODO
+    return shared_from_this();
+}
+
+shared_ptr<CKKSTensor> CKKSTensor::sub_plain_inplace(const double& to_sub) {
+    // TODO
+    return shared_from_this();
+}
+
+shared_ptr<CKKSTensor> CKKSTensor::mul_plain_inplace(const double& to_mul) {
+    // TODO
+    return shared_from_this();
+}
+
+shared_ptr<CKKSTensor> CKKSTensor::sum_inplace(size_t axis) {
+    // TODO
+    return shared_from_this();
+}
+
+shared_ptr<CKKSTensor> CKKSTensor::polyval_inplace(
+    const vector<double>& coefficients) {
+    // TODO
+    return shared_from_this();
+}
+
+void CKKSTensor::load(const string& vec) {
+    // TODO
+}
+
+string CKKSTensor::save() const {
+    // TODO
+    return "saving";
+}
+
+shared_ptr<CKKSTensor> CKKSTensor::copy() const {
+    // TODO
+}
+
+shared_ptr<CKKSTensor> CKKSTensor::deepcopy() const {
+    // TODO
 }
 
 }  // namespace tenseal

--- a/tenseal/cpp/tensors/ckkstensor.h
+++ b/tenseal/cpp/tensors/ckkstensor.h
@@ -2,25 +2,26 @@
 #define TENSEAL_TENSOR_CKKSTENSOR_H
 
 #include "tenseal/cpp/tensors/encrypted_tensor.h"
+#include "tenseal/cpp/tensors/plain_tensor.h"
 
 namespace tenseal {
 
 using namespace seal;
 using namespace std;
 
-class CKKSTensor : public EncryptedTensor<double, shared_ptr<CKKSTensor>> {
+class CKKSTensor : public EncryptedTensor<double, shared_ptr<CKKSTensor>>,
+                   public enable_shared_from_this<CKKSTensor> {
    public:
-    
     /**
      * Create a new CKKSTensor from an 1D vector.
      * @param[in] input vector.
      * @param[in] input vector.
      * @param[in] input vector.
      */
-    static shared_ptr<CKKSTensor> Create(const shared_ptr<TenSEALContext>& ctx,
-                                         const vector<double>& data,
-                                         std::optional<double> scale) {
-        return shared_ptr<CKKSTensor>(new CKKSTensor(ctx, data, scale));
+    template <typename... Args>
+    static shared_ptr<CKKSTensor> Create(Args&&... args) {
+        return shared_ptr<CKKSTensor>(
+            new CKKSTensor(std::forward<Args>(args)...));
     }
 
     PlainTensor<double> decrypt() const override;
@@ -74,7 +75,8 @@ class CKKSTensor : public EncryptedTensor<double, shared_ptr<CKKSTensor>> {
     double _init_scale;
 
     CKKSTensor(const shared_ptr<TenSEALContext>& ctx,
-               const vector<double>& data, std::optional<double> scale = {});
+               const PlainTensor<double>& tensor,
+               std::optional<double> scale = {});
 
     static Ciphertext encrypt(const shared_ptr<TenSEALContext>& ctx,
                               const double scale, const vector<double>& data);

--- a/tenseal/cpp/tensors/ckkstensor.h
+++ b/tenseal/cpp/tensors/ckkstensor.h
@@ -1,0 +1,87 @@
+#ifndef TENSEAL_TENSOR_CKKSTENSOR_H
+#define TENSEAL_TENSOR_CKKSTENSOR_H
+
+#include "tenseal/cpp/tensors/encrypted_tensor.h"
+
+namespace tenseal {
+
+using namespace seal;
+using namespace std;
+
+class CKKSTensor : public EncryptedTensor<double, shared_ptr<CKKSTensor>> {
+   public:
+    
+    /**
+     * Create a new CKKSTensor from an 1D vector.
+     * @param[in] input vector.
+     * @param[in] input vector.
+     * @param[in] input vector.
+     */
+    static shared_ptr<CKKSTensor> Create(const shared_ptr<TenSEALContext>& ctx,
+                                         const vector<double>& data,
+                                         std::optional<double> scale) {
+        return shared_ptr<CKKSTensor>(new CKKSTensor(ctx, data, scale));
+    }
+
+    PlainTensor<double> decrypt() const override;
+    PlainTensor<double> decrypt(const shared_ptr<SecretKey>& sk) const override;
+
+    shared_ptr<CKKSTensor> negate_inplace() override;
+    shared_ptr<CKKSTensor> square_inplace() override;
+    shared_ptr<CKKSTensor> power_inplace(unsigned int power) override;
+
+    shared_ptr<CKKSTensor> add_inplace(
+        const shared_ptr<CKKSTensor>& to_add) override;
+    shared_ptr<CKKSTensor> sub_inplace(
+        const shared_ptr<CKKSTensor>& to_sub) override;
+    shared_ptr<CKKSTensor> mul_inplace(
+        const shared_ptr<CKKSTensor>& to_mul) override;
+    shared_ptr<CKKSTensor> dot_product_inplace(
+        const shared_ptr<CKKSTensor>& to_mul) override;
+
+    shared_ptr<CKKSTensor> add_plain_inplace(const double& to_add) override;
+    shared_ptr<CKKSTensor> sub_plain_inplace(const double& to_sub) override;
+    shared_ptr<CKKSTensor> mul_plain_inplace(const double& to_mul) override;
+
+    shared_ptr<CKKSTensor> add_plain_inplace(
+        const PlainTensor<double>& to_add) override;
+    shared_ptr<CKKSTensor> sub_plain_inplace(
+        const PlainTensor<double>& to_sub) override;
+    shared_ptr<CKKSTensor> mul_plain_inplace(
+        const PlainTensor<double>& to_mul) override;
+    shared_ptr<CKKSTensor> dot_product_plain_inplace(
+        const PlainTensor<double>& to_mul) override;
+
+    shared_ptr<CKKSTensor> sum_inplace() {
+        // default axis=0
+        return this->sum_inplace(0);
+    }
+    shared_ptr<CKKSTensor> sum_inplace(size_t axis = 0);
+
+    shared_ptr<CKKSTensor> polyval_inplace(
+        const vector<double>& coefficients) override;
+
+    void load(const string& vec) override;
+    string save() const override;
+
+    shared_ptr<CKKSTensor> copy() const override;
+    shared_ptr<CKKSTensor> deepcopy() const override;
+
+   private:
+    vector<Ciphertext> _data;
+    vector<size_t> _shape;
+    vector<size_t> _strides;
+    double _init_scale;
+
+    CKKSTensor(const shared_ptr<TenSEALContext>& ctx,
+               const vector<double>& data, std::optional<double> scale = {});
+
+    static Ciphertext encrypt(const shared_ptr<TenSEALContext>& ctx,
+                              const double scale, const vector<double>& data);
+    static Ciphertext encrypt(const shared_ptr<TenSEALContext>& ctx,
+                              const double scale, const double data);
+};
+
+}  // namespace tenseal
+
+#endif

--- a/tenseal/tensors/__init__.py
+++ b/tenseal/tensors/__init__.py
@@ -121,14 +121,14 @@ def ckks_vector_from(context, data):
 
 
 def ckks_tensor(context, tensor, scale=None):
-    """Constructor method for the CKKSVector object, which can store a list
+    """Constructor method for the CKKSTensor object, which can store a list
     of float numbers in encrypted form, using the CKKS homomorphic encryption
     scheme.
 
     Args:
         context: a TenSEALContext object, holding the encryption parameters and keys.
         tensor: a PlainTensorDouble holding data to be encrypted.
-        scale: the scale to be used to encode vector values. CKKSVector will use the global_scale provided by the context if it's set to None.
+        scale: the scale to be used to encode vector values. CKKSTensor will use the global_scale provided by the context if it's set to None.
 
     Returns:
         CKKSTensor object.

--- a/tenseal/tensors/__init__.py
+++ b/tenseal/tensors/__init__.py
@@ -8,6 +8,23 @@ except ImportError:
     import tenseal._tenseal_cpp as _ts_cpp
 
 
+def plain_tensor(data, shape=None, stride=None, dtype="float"):
+    """Constructor method for the PlainTensor object.
+    Args:
+        data:
+        shape:
+        stride:
+        dtype:
+    Returns:
+        PlainTensor object.
+    """
+    # just create a plaintensor using python lists for now
+    if dtype == "float":
+        return _ts_cpp.PlainTensorDouble(data)
+    else:
+        raise ValueError("Invalid dtype")
+
+
 def bfv_vector(context, data):
     """Constructor method for the BFVVector object, which can store a list
     of integers in encrypted form, using the BFV homomorphic encryption
@@ -103,4 +120,32 @@ def ckks_vector_from(context, data):
     )
 
 
-__all__ = ["bfv_vector", "bfv_vector_from", "ckks_vector", "ckks_vector_from"]
+def ckks_tensor(context, tensor, scale=None):
+    """Constructor method for the CKKSVector object, which can store a list
+    of float numbers in encrypted form, using the CKKS homomorphic encryption
+    scheme.
+
+    Args:
+        context: a TenSEALContext object, holding the encryption parameters and keys.
+        tensor: a PlainTensorDouble holding data to be encrypted.
+        scale: the scale to be used to encode vector values. CKKSVector will use the global_scale provided by the context if it's set to None.
+
+    Returns:
+        CKKSTensor object.
+    """
+    if isinstance(context, _ts_cpp.TenSEALContext) and isinstance(
+        tensor, _ts_cpp.PlainTensorDouble
+    ):
+        if scale is None:
+            return _ts_cpp.CKKSTensor(context, tensor)
+        else:
+            return _ts_cpp.CKKSTensor(context, tensor, scale)
+
+    raise TypeError(
+        "Invalid CKKSTensor input types context: {} and vector: {}".format(
+            type(context), type(tensor)
+        )
+    )
+
+
+__all__ = ["bfv_vector", "bfv_vector_from", "ckks_vector", "ckks_vector_from", "ckks_tensor"]

--- a/tests/python/tenseal/test_enc_dec.py
+++ b/tests/python/tenseal/test_enc_dec.py
@@ -1,5 +1,7 @@
 import pytest
 import tenseal as ts
+import numpy as np
+
 
 PLAIN_VEC = [
     [0],
@@ -94,3 +96,16 @@ def test_ckks_empty_encryption(plain_vec):
     with pytest.raises(ValueError) as e:
         ckks_vec = ts.ckks_vector(context, plain_vec, scale)
     assert str(e.value) == "Attempting to encrypt an empty vector"
+
+
+def test_ckks_tensor_encryption_decryption():
+    context = ts.context(ts.SCHEME_TYPE.CKKS, 8192, coeff_mod_bit_sizes=COEFF_MOD_BIT_SIZES)
+    scale = pow(2, 40)
+    matrix = np.random.randn(4, 5)
+    plain_tensor = ts.plain_tensor(matrix.tolist())
+    ckks_vec = ts.ckks_tensor(context, plain_tensor, scale)
+    decrypted_vec = ckks_vec.decrypt()
+    # TODO: don't use the flattened version
+    assert _almost_equal(
+        decrypted_vec, matrix.flatten().tolist(), 1
+    ), "Decryption of vector is incorrect"


### PR DESCRIPTION
## Description
This introduce an encrypted tensor using CKKS. It can stores an N-dimensional plain tensor into a (N-1)-dimensional encrypted tensor by batching one of the axis into the ciphertexts.


## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
