### PR TITLE
static protobuf

### DIFF
--- a/.github/workflows/scripts/install_req_centos.sh
+++ b/.github/workflows/scripts/install_req_centos.sh
@@ -7,7 +7,7 @@ curl https://github.com/Kitware/CMake/releases/download/v3.17.1/cmake-3.17.1-Lin
 echo "::add-path::/opt/cmake-3.17.1-Linux-x86_64/bin"
 
 # install latest protobuf release
-curl https://github.com/protocolbuffers/protobuf/releases/download/v3.13.0/protobuf-cpp-3.14.0.tar.gz -L | tar xz -C /opt/
+curl https://github.com/protocolbuffers/protobuf/releases/download/v3.14.0/protobuf-cpp-3.14.0.tar.gz -L | tar xz -C /opt/
 pushd /opt/protobuf-3.14.0
 ./configure CXXFLAGS=-fPIC
 make

--- a/.github/workflows/scripts/install_req_centos.sh
+++ b/.github/workflows/scripts/install_req_centos.sh
@@ -7,9 +7,9 @@ curl https://github.com/Kitware/CMake/releases/download/v3.17.1/cmake-3.17.1-Lin
 echo "::add-path::/opt/cmake-3.17.1-Linux-x86_64/bin"
 
 # install latest protobuf release
-curl https://github.com/protocolbuffers/protobuf/releases/download/v3.13.0/protobuf-cpp-3.13.0.tar.gz -L | tar xz -C /opt/
-pushd /opt/protobuf-3.13.0
-./configure
+curl https://github.com/protocolbuffers/protobuf/releases/download/v3.13.0/protobuf-cpp-3.14.0.tar.gz -L | tar xz -C /opt/
+pushd /opt/protobuf-3.14.0
+./configure CXXFLAGS=-fPIC
 make
 make install
 ldconfig

--- a/.github/workflows/scripts/install_req_ubuntu.sh
+++ b/.github/workflows/scripts/install_req_ubuntu.sh
@@ -3,7 +3,18 @@
 set -e
 
 sudo apt update
-sudo apt install cmake clang libprotobuf-dev protobuf-compiler
+sudo apt install cmake automake
+
+cd third_party/protobuf/ && \
+    git submodule update --init --recursive && \
+    autoreconf --install && \
+    ./configure CXXFLAGS=-fPIC && \
+    make && sudo make install && cd -
+
+if [ $? -ne 0 ]
+then
+    exit 1
+fi
 
 python -m pip install --upgrade pip
 pip install -r requirements_dev.txt

--- a/.github/workflows/scripts/install_req_ubuntu.sh
+++ b/.github/workflows/scripts/install_req_ubuntu.sh
@@ -5,6 +5,14 @@ set -e
 sudo apt update
 sudo apt install cmake clang libprotobuf-dev protobuf-compiler
 
+PROTOBUF_VERSION=3.14.0 && \
+    curl -L https://github.com/google/protobuf/releases/download/v${PROTOBUF_VERSION}/protobuf-all-${PROTOBUF_VERSION}.tar.gz | tar -xzf - && \
+    cd /protobuf-${PROTOBUF_VERSION} && \
+    ./autogen.sh && \
+    ./configure CXXFLAGS="-fPIC" --prefix=/usr/local --disable-shared 2>&1 > /dev/null && \
+    make -j"$(grep ^processor /proc/cpuinfo | wc -l)" install 2>&1 > /dev/null && \
+    rm -rf /protobuf-${PROTOBUF_VERSION}
+
 python -m pip install --upgrade pip
 pip install -r requirements_dev.txt
 pip install setuptools wheel twine auditwheel

--- a/.github/workflows/scripts/install_req_ubuntu.sh
+++ b/.github/workflows/scripts/install_req_ubuntu.sh
@@ -9,7 +9,7 @@ cd third_party/protobuf/ && \
     git submodule update --init --recursive && \
     autoreconf --install && \
     ./configure CXXFLAGS=-fPIC && \
-    make && sudo make install && cd -
+    make && sudo make install && sudo ldconfig && cd -
 
 if [ $? -ne 0 ]
 then

--- a/.github/workflows/scripts/install_req_ubuntu.sh
+++ b/.github/workflows/scripts/install_req_ubuntu.sh
@@ -5,14 +5,6 @@ set -e
 sudo apt update
 sudo apt install cmake clang libprotobuf-dev protobuf-compiler
 
-PROTOBUF_VERSION=3.14.0 && \
-    curl -L https://github.com/google/protobuf/releases/download/v${PROTOBUF_VERSION}/protobuf-all-${PROTOBUF_VERSION}.tar.gz | tar -xzf - && \
-    cd /protobuf-${PROTOBUF_VERSION} && \
-    ./autogen.sh && \
-    ./configure CXXFLAGS="-fPIC" --prefix=/usr/local --disable-shared 2>&1 > /dev/null && \
-    make -j"$(grep ^processor /proc/cpuinfo | wc -l)" install 2>&1 > /dev/null && \
-    rm -rf /protobuf-${PROTOBUF_VERSION}
-
 python -m pip install --upgrade pip
 pip install -r requirements_dev.txt
 pip install setuptools wheel twine auditwheel

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "third_party/googletest"]
 	path = third_party/googletest
 	url = https://github.com/google/googletest
+[submodule "third_party/protobuf"]
+	path = third_party/protobuf
+	url = https://github.com/protocolbuffers/protobuf

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ project(tenseal)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 include_directories(${CMAKE_CURRENT_BINARY_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,99 +6,10 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
-include_directories(third_party/SEAL/native/src)
-
-# ##############################################################################
-# Third party
-# ##############################################################################
-if(WIN32)
-  set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MT")
-  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MTd")
-
-  include_directories(protobuf/src)
-  link_libraries("$ENV{PROGRAMFILES\(x86\)}/protobuf/lib/libprotobuf-lite.lib")
-  link_libraries("$ENV{PROGRAMFILES\(x86\)}/protobuf/lib/libprotobuf.lib")
-  link_libraries("$ENV{PROGRAMFILES\(x86\)}/protobuf/lib/libprotoc.lib")
-else()
-  # building protobuf using cmake
-  add_subdirectory(tenseal/proto)
-
-  set(Protobuf_USE_STATIC_LIBS ON)
-  set(Protobuf_DEBUG ON)
-
-  find_package(Protobuf REQUIRED)
-  include(FindProtobuf)
-  include_directories(${Protobuf_INCLUDE_DIRS})
-endif()
-
-set(SEAL_BUILD_DEPS ON)
-
-# building SEAL using cmake
-add_subdirectory(third_party/SEAL)
-
-add_subdirectory(third_party/pybind11)
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
-# ##############################################################################
-# Core
-# ##############################################################################
-set(TENSEAL_BASEDIR tenseal)
-set(SEALAPI_BASEDIR tenseal/sealapi)
-
-set(SOURCES
-    ${TENSEAL_BASEDIR}/cpp/context/tensealcontext.cpp
-    ${TENSEAL_BASEDIR}/cpp/context/sealcontext.cpp
-    ${TENSEAL_BASEDIR}/cpp/tensors/bfvvector.cpp
-    ${TENSEAL_BASEDIR}/cpp/tensors/ckkstensor.cpp
-    ${TENSEAL_BASEDIR}/cpp/tensors/ckksvector.cpp
-    ${TENSEAL_BASEDIR}/cpp/tensors/utils/utils.cpp)
-if(WIN32)
-  set(SOURCES ${SOURCES} ${TENSEAL_BASEDIR}/proto/tensealcontext.pb.cc
-              ${TENSEAL_BASEDIR}/proto/tensors.pb.cc)
-endif()
-
-add_library(tenseal SHARED ${SOURCES})
-pybind11_add_module(_tenseal_cpp ${SOURCES} ${TENSEAL_BASEDIR}/binding.cpp)
-
-set(SEALAPI_SOURCES
-    ${SEALAPI_BASEDIR}/sealapi.cpp
-    ${SEALAPI_BASEDIR}/sealapi_evaluator.cpp
-    ${SEALAPI_BASEDIR}/sealapi_encrypt.cpp
-    ${SEALAPI_BASEDIR}/sealapi_helpers.cpp
-    ${SEALAPI_BASEDIR}/sealapi_modulus.cpp
-    ${SEALAPI_BASEDIR}/sealapi_encode.cpp
-    ${SEALAPI_BASEDIR}/sealapi_context.cpp
-    ${SEALAPI_BASEDIR}/sealapi_util_namespace.cpp)
-pybind11_add_module(_sealapi_cpp ${SEALAPI_SOURCES})
-
-target_link_libraries(_sealapi_cpp PRIVATE seal)
-target_link_libraries(_tenseal_cpp PRIVATE seal)
-target_link_libraries(tenseal PRIVATE seal)
-if(NOT WIN32)
-  target_link_libraries(tenseal PRIVATE tenseal_proto)
-  target_link_libraries(_tenseal_cpp PRIVATE tenseal_proto)
-endif()
-
-# ##############################################################################
-# Unit Tests
-# ##############################################################################
-if(${BUILD_TEST})
-  add_subdirectory(third_party/googletest)
-  enable_testing()
-  include_directories(${gtest_SOURCE_DIR}/include ${gtest_SOURCE_DIR}
-                      ${gmock_SOURCE_DIR}/include third_party/SEAL)
-
-  set(TENSEAL_TESTS_BASEDIR tests/cpp)
-  set(TESTING_SOURCES
-      ${TENSEAL_TESTS_BASEDIR}/tensealcontext_test.cpp
-      ${TENSEAL_TESTS_BASEDIR}/tensors/ckksvector_test.cpp
-      ${TENSEAL_TESTS_BASEDIR}/tensors/ckkstensor_test.cpp
-      ${TENSEAL_TESTS_BASEDIR}/tensors/plaintensor_test.cpp
-      ${TENSEAL_TESTS_BASEDIR}/tensors/bfvvector_test.cpp)
-  add_executable(tenseal_tests ${TESTING_SOURCES} ${SOURCES})
-  target_link_libraries(tenseal_tests PRIVATE gtest gtest_main seal)
-  if(NOT WIN32)
-    target_link_libraries(tenseal_tests PRIVATE tenseal tenseal_proto)
-  endif()
-  add_test(tenseal_tests tenseal_tests)
-endif()
+include(cmake/seal.cmake)
+include(cmake/protobuf.cmake)
+include(cmake/pybind11.cmake)
+include(cmake/tenseal.cmake)
+include(cmake/tests.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,9 @@ else()
   # building protobuf using cmake
   add_subdirectory(tenseal/proto)
 
+  set(Protobuf_USE_STATIC_LIBS ON)
+  set(Protobuf_DEBUG ON)
+
   find_package(Protobuf REQUIRED)
   include(FindProtobuf)
   include_directories(${Protobuf_INCLUDE_DIRS})

--- a/cmake/protobuf.cmake
+++ b/cmake/protobuf.cmake
@@ -1,0 +1,21 @@
+if(WIN32)
+  set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MT")
+  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MTd")
+
+  include_directories(protobuf/src)
+  link_libraries("$ENV{PROGRAMFILES\(x86\)}/protobuf/lib/libprotobuf-lite.lib")
+  link_libraries("$ENV{PROGRAMFILES\(x86\)}/protobuf/lib/libprotobuf.lib")
+  link_libraries("$ENV{PROGRAMFILES\(x86\)}/protobuf/lib/libprotoc.lib")
+else()
+  # building protobuf using cmake
+  add_subdirectory(tenseal/proto)
+
+  set(Protobuf_USE_STATIC_LIBS ON)
+  set(Protobuf_DEBUG ON)
+
+  find_package(Protobuf REQUIRED)
+  include(FindProtobuf)
+  include_directories(${Protobuf_INCLUDE_DIRS})
+endif()
+
+

--- a/cmake/protobuf.cmake
+++ b/cmake/protobuf.cmake
@@ -7,15 +7,7 @@ if(WIN32)
   link_libraries("$ENV{PROGRAMFILES\(x86\)}/protobuf/lib/libprotobuf.lib")
   link_libraries("$ENV{PROGRAMFILES\(x86\)}/protobuf/lib/libprotoc.lib")
 else()
-  # building protobuf using cmake
   add_subdirectory(tenseal/proto)
-
-  set(Protobuf_USE_STATIC_LIBS ON)
-  set(Protobuf_DEBUG ON)
-
-  find_package(Protobuf REQUIRED)
-  include(FindProtobuf)
-  include_directories(${Protobuf_INCLUDE_DIRS})
 endif()
 
 

--- a/cmake/protobuf.cmake
+++ b/cmake/protobuf.cmake
@@ -7,7 +7,15 @@ if(WIN32)
   link_libraries("$ENV{PROGRAMFILES\(x86\)}/protobuf/lib/libprotobuf.lib")
   link_libraries("$ENV{PROGRAMFILES\(x86\)}/protobuf/lib/libprotoc.lib")
 else()
+  # building protobuf using cmake
   add_subdirectory(tenseal/proto)
+
+  set(Protobuf_USE_STATIC_LIBS ON)
+  set(Protobuf_DEBUG ON)
+
+  find_package(Protobuf REQUIRED)
+  include(FindProtobuf)
+  include_directories(${Protobuf_INCLUDE_DIRS})
 endif()
 
 

--- a/cmake/pybind11.cmake
+++ b/cmake/pybind11.cmake
@@ -1,0 +1,1 @@
+add_subdirectory(third_party/pybind11)

--- a/cmake/seal.cmake
+++ b/cmake/seal.cmake
@@ -1,5 +1,3 @@
 include_directories(third_party/SEAL/native/src)
 set(SEAL_BUILD_DEPS ON)
 add_subdirectory(third_party/SEAL)
-
-

--- a/cmake/seal.cmake
+++ b/cmake/seal.cmake
@@ -1,0 +1,5 @@
+include_directories(third_party/SEAL/native/src)
+set(SEAL_BUILD_DEPS ON)
+add_subdirectory(third_party/SEAL)
+
+

--- a/cmake/tenseal.cmake
+++ b/cmake/tenseal.cmake
@@ -1,0 +1,38 @@
+set(TENSEAL_BASEDIR tenseal)
+set(SEALAPI_BASEDIR tenseal/sealapi)
+
+set(SOURCES
+    ${TENSEAL_BASEDIR}/cpp/context/tensealcontext.cpp
+    ${TENSEAL_BASEDIR}/cpp/context/sealcontext.cpp
+    ${TENSEAL_BASEDIR}/cpp/tensors/bfvvector.cpp
+    ${TENSEAL_BASEDIR}/cpp/tensors/ckkstensor.cpp
+    ${TENSEAL_BASEDIR}/cpp/tensors/ckksvector.cpp
+    ${TENSEAL_BASEDIR}/cpp/tensors/utils/utils.cpp)
+if(WIN32)
+  set(SOURCES ${SOURCES} ${TENSEAL_BASEDIR}/proto/tensealcontext.pb.cc
+              ${TENSEAL_BASEDIR}/proto/tensors.pb.cc)
+endif()
+
+add_library(tenseal SHARED ${SOURCES})
+pybind11_add_module(_tenseal_cpp ${SOURCES} ${TENSEAL_BASEDIR}/binding.cpp)
+
+set(SEALAPI_SOURCES
+    ${SEALAPI_BASEDIR}/sealapi.cpp
+    ${SEALAPI_BASEDIR}/sealapi_evaluator.cpp
+    ${SEALAPI_BASEDIR}/sealapi_encrypt.cpp
+    ${SEALAPI_BASEDIR}/sealapi_helpers.cpp
+    ${SEALAPI_BASEDIR}/sealapi_modulus.cpp
+    ${SEALAPI_BASEDIR}/sealapi_encode.cpp
+    ${SEALAPI_BASEDIR}/sealapi_context.cpp
+    ${SEALAPI_BASEDIR}/sealapi_util_namespace.cpp)
+pybind11_add_module(_sealapi_cpp ${SEALAPI_SOURCES})
+
+target_link_libraries(_sealapi_cpp PRIVATE seal)
+target_link_libraries(_tenseal_cpp PRIVATE seal)
+target_link_libraries(tenseal PRIVATE seal)
+if(NOT WIN32)
+  target_link_libraries(tenseal PRIVATE tenseal_proto)
+  target_link_libraries(_tenseal_cpp PRIVATE tenseal_proto)
+endif()
+
+

--- a/cmake/tests.cmake
+++ b/cmake/tests.cmake
@@ -1,0 +1,20 @@
+if(${BUILD_TEST})
+  add_subdirectory(third_party/googletest)
+  enable_testing()
+  include_directories(${gtest_SOURCE_DIR}/include ${gtest_SOURCE_DIR}
+                      ${gmock_SOURCE_DIR}/include third_party/SEAL)
+
+  set(TENSEAL_TESTS_BASEDIR tests/cpp)
+  set(TESTING_SOURCES
+      ${TENSEAL_TESTS_BASEDIR}/tensealcontext_test.cpp
+      ${TENSEAL_TESTS_BASEDIR}/tensors/ckksvector_test.cpp
+      ${TENSEAL_TESTS_BASEDIR}/tensors/ckkstensor_test.cpp
+      ${TENSEAL_TESTS_BASEDIR}/tensors/plaintensor_test.cpp
+      ${TENSEAL_TESTS_BASEDIR}/tensors/bfvvector_test.cpp)
+  add_executable(tenseal_tests ${TESTING_SOURCES} ${SOURCES})
+  target_link_libraries(tenseal_tests PRIVATE gtest gtest_main seal)
+  if(NOT WIN32)
+    target_link_libraries(tenseal_tests PRIVATE tenseal tenseal_proto)
+  endif()
+  add_test(tenseal_tests tenseal_tests)
+endif()

--- a/tenseal/proto/CMakeLists.txt
+++ b/tenseal/proto/CMakeLists.txt
@@ -1,15 +1,17 @@
-set(CMAKE_CXX_STANDARD 17)	
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
-find_package(Protobuf REQUIRED)
+set(Protobuf_USE_STATIC_LIBS ON)
 
 include(FindProtobuf)
+find_package(Protobuf REQUIRED)
+
 include_directories(${Protobuf_INCLUDE_DIRS})
-set(Protobuf_USE_STATIC_LIBS YES)
 
 file(GLOB PROTOBUF_FILELIST tensealcontext.proto tensors.proto)
 
 protobuf_generate_cpp(PROTO_SRC PROTO_INCL ${PROTOBUF_FILELIST})
 add_library(tenseal_proto ${PROTO_HEADER} ${PROTO_SRC})
 target_link_libraries(tenseal_proto INTERFACE ${Protobuf_LIBRARIES})
+
 set_property(TARGET tenseal_proto PROPERTY POSITION_INDEPENDENT_CODE ON)

--- a/tenseal/proto/CMakeLists.txt
+++ b/tenseal/proto/CMakeLists.txt
@@ -1,3 +1,6 @@
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+
 set(Protobuf_USE_STATIC_LIBS ON)
 
 include(FindProtobuf)

--- a/tenseal/proto/CMakeLists.txt
+++ b/tenseal/proto/CMakeLists.txt
@@ -1,6 +1,3 @@
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED True)
-
 set(Protobuf_USE_STATIC_LIBS ON)
 
 include(FindProtobuf)


### PR DESCRIPTION
 - Linux protobuf packages are not built with -fPIC, we need to build them from scratch, to be able to link them statically.
 - cleanup CMakeList.txt

fixes https://github.com/OpenMined/TenSEAL/issues/175

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
