### PR TITLE
ID field for serializable objects

### DIFF
--- a/tenseal/binding.cpp
+++ b/tenseal/binding.cpp
@@ -65,10 +65,8 @@ PYBIND11_MODULE(_tenseal_cpp, m) {
 
     py::class_<BFVVector, std::shared_ptr<BFVVector>>(m, "BFVVector",
                                                       py::module_local())
-        .def_property(
-            "id",
-            py::overload_cast<>(&BFVVector::id, py::const_),
-            py::overload_cast<uint64_t>(&BFVVector::id))
+        .def_property("id", py::overload_cast<>(&BFVVector::id, py::const_),
+                      py::overload_cast<uint64_t>(&BFVVector::id))
         .def(py::init([](const shared_ptr<TenSEALContext> &ctx,
                          const vector<int64_t> &data) {
             return BFVVector::Create(ctx, data);
@@ -202,10 +200,8 @@ PYBIND11_MODULE(_tenseal_cpp, m) {
 
     py::class_<CKKSVector, std::shared_ptr<CKKSVector>>(m, "CKKSVector",
                                                         py::module_local())
-        .def_property(
-            "id",
-            py::overload_cast<>(&CKKSVector::id, py::const_),
-            py::overload_cast<uint64_t>(&CKKSVector::id))
+        .def_property("id", py::overload_cast<>(&CKKSVector::id, py::const_),
+                      py::overload_cast<uint64_t>(&CKKSVector::id))
         // specifying scale
         .def(py::init([](const shared_ptr<TenSEALContext> &ctx,
                          const vector<double> &data, double scale) {
@@ -437,10 +433,8 @@ PYBIND11_MODULE(_tenseal_cpp, m) {
 
     py::class_<CKKSTensor, std::shared_ptr<CKKSTensor>>(m, "CKKSTensor",
                                                         py::module_local())
-        .def_property(
-            "id",
-            py::overload_cast<>(&CKKSTensor::id, py::const_),
-            py::overload_cast<uint64_t>(&CKKSTensor::id))
+        .def_property("id", py::overload_cast<>(&CKKSTensor::id, py::const_),
+                      py::overload_cast<uint64_t>(&CKKSTensor::id))
         .def(py::init([](const shared_ptr<TenSEALContext> &ctx,
                          const PlainTensor<double> &tensor, double scale,
                          bool batch) {
@@ -600,10 +594,9 @@ PYBIND11_MODULE(_tenseal_cpp, m) {
             "auto_mod_switch",
             py::overload_cast<>(&TenSEALContext::auto_mod_switch, py::const_),
             py::overload_cast<bool>(&TenSEALContext::auto_mod_switch))
-        .def_property(
-            "id",
-            py::overload_cast<>(&TenSEALContext::id, py::const_),
-            py::overload_cast<uint64_t>(&TenSEALContext::id))
+        .def_property("id",
+                      py::overload_cast<>(&TenSEALContext::id, py::const_),
+                      py::overload_cast<uint64_t>(&TenSEALContext::id))
         .def("new",
              py::overload_cast<scheme_type, size_t, uint64_t, vector<int>,
                                optional<size_t>>(&TenSEALContext::Create),

--- a/tenseal/binding.cpp
+++ b/tenseal/binding.cpp
@@ -65,6 +65,10 @@ PYBIND11_MODULE(_tenseal_cpp, m) {
 
     py::class_<BFVVector, std::shared_ptr<BFVVector>>(m, "BFVVector",
                                                       py::module_local())
+        .def_property(
+            "id",
+            py::overload_cast<>(&BFVVector::id, py::const_),
+            py::overload_cast<uint64_t>(&BFVVector::id))
         .def(py::init([](const shared_ptr<TenSEALContext> &ctx,
                          const vector<int64_t> &data) {
             return BFVVector::Create(ctx, data);
@@ -198,6 +202,10 @@ PYBIND11_MODULE(_tenseal_cpp, m) {
 
     py::class_<CKKSVector, std::shared_ptr<CKKSVector>>(m, "CKKSVector",
                                                         py::module_local())
+        .def_property(
+            "id",
+            py::overload_cast<>(&CKKSVector::id, py::const_),
+            py::overload_cast<uint64_t>(&CKKSVector::id))
         // specifying scale
         .def(py::init([](const shared_ptr<TenSEALContext> &ctx,
                          const vector<double> &data, double scale) {
@@ -429,6 +437,10 @@ PYBIND11_MODULE(_tenseal_cpp, m) {
 
     py::class_<CKKSTensor, std::shared_ptr<CKKSTensor>>(m, "CKKSTensor",
                                                         py::module_local())
+        .def_property(
+            "id",
+            py::overload_cast<>(&CKKSTensor::id, py::const_),
+            py::overload_cast<uint64_t>(&CKKSTensor::id))
         .def(py::init([](const shared_ptr<TenSEALContext> &ctx,
                          const PlainTensor<double> &tensor, double scale,
                          bool batch) {
@@ -588,6 +600,10 @@ PYBIND11_MODULE(_tenseal_cpp, m) {
             "auto_mod_switch",
             py::overload_cast<>(&TenSEALContext::auto_mod_switch, py::const_),
             py::overload_cast<bool>(&TenSEALContext::auto_mod_switch))
+        .def_property(
+            "id",
+            py::overload_cast<>(&TenSEALContext::id, py::const_),
+            py::overload_cast<uint64_t>(&TenSEALContext::id))
         .def("new",
              py::overload_cast<scheme_type, size_t, uint64_t, vector<int>,
                                optional<size_t>>(&TenSEALContext::Create),

--- a/tenseal/cpp/context/tensealcontext.cpp
+++ b/tenseal/cpp/context/tensealcontext.cpp
@@ -304,8 +304,8 @@ bool TenSEALContext::equals(
 }
 
 void TenSEALContext::load_proto(const TenSEALContextProto& buffer) {
-    this->base_setup(
-        buffer.id(), SEALDeserialize<EncryptionParameters>(buffer.encryption_parameters()));
+    this->base_setup(buffer.id(), SEALDeserialize<EncryptionParameters>(
+                                      buffer.encryption_parameters()));
     this->_auto_flags = buffer.public_context().auto_flags();
     if (buffer.public_context().scale() >= 0) {
         this->global_scale(buffer.public_context().scale());

--- a/tenseal/cpp/context/tensealcontext.h
+++ b/tenseal/cpp/context/tensealcontext.h
@@ -249,6 +249,9 @@ class TenSEALContext {
     bool has_secret_key() const;
     bool has_relin_keys() const;
 
+    uint64_t id() const{return _id;}
+    void id(uint64_t new_id) {_id = new_id;}
+
    private:
     EncryptionParameters _parms;
     shared_ptr<SEALContext> _context;
@@ -260,6 +263,7 @@ class TenSEALContext {
 
     shared_ptr<sync::ThreadPool> _dispatcher;
     size_t _threads;
+    uint64_t _id;
 
     /**
      * Switches for automatic relinearization, rescaling, and modulus switching
@@ -278,7 +282,7 @@ class TenSEALContext {
     TenSEALContext(const TenSEALContextProto& proto,
                    optional<size_t> n_threads);
 
-    void base_setup(EncryptionParameters parms);
+    void base_setup(uint64_t id, EncryptionParameters parms);
     void dispatcher_setup(optional<size_t> n_threads);
     void keys_setup(optional<PublicKey> public_key = {},
                     optional<SecretKey> secret_key = {},

--- a/tenseal/cpp/context/tensealcontext.h
+++ b/tenseal/cpp/context/tensealcontext.h
@@ -249,8 +249,8 @@ class TenSEALContext {
     bool has_secret_key() const;
     bool has_relin_keys() const;
 
-    uint64_t id() const{return _id;}
-    void id(uint64_t new_id) {_id = new_id;}
+    uint64_t id() const { return _id; }
+    void id(uint64_t new_id) { _id = new_id; }
 
    private:
     EncryptionParameters _parms;

--- a/tenseal/cpp/tensors/bfvvector.cpp
+++ b/tenseal/cpp/tensors/bfvvector.cpp
@@ -38,6 +38,7 @@ BFVVector::BFVVector(const TenSEALContextProto& ctx,
 BFVVector::BFVVector(const shared_ptr<const BFVVector>& vec) {
     this->prepare_context(vec->tenseal_context());
     this->_size = vec->size();
+    this->_id = vec->id();
     this->_ciphertext = vec->ciphertext();
 }
 
@@ -306,6 +307,7 @@ void BFVVector::load_proto(const BFVVectorProto& vec) {
     if (this->tenseal_context() == nullptr) {
         throw invalid_argument("context missing for deserialization");
     }
+    this->_id = vec.id();
     this->_size = vec.size();
     this->_ciphertext = SEALDeserialize<Ciphertext>(
         *this->tenseal_context()->seal_context(), vec.ciphertext());
@@ -314,6 +316,7 @@ void BFVVector::load_proto(const BFVVectorProto& vec) {
 BFVVectorProto BFVVector::save_proto() const {
     BFVVectorProto buffer;
 
+    buffer.set_id(this->_id);
     *buffer.mutable_ciphertext() = SEALSerialize<Ciphertext>(this->_ciphertext);
     buffer.set_size(static_cast<int>(this->_size));
 

--- a/tenseal/cpp/tensors/ckkstensor.cpp
+++ b/tenseal/cpp/tensors/ckkstensor.cpp
@@ -54,6 +54,7 @@ CKKSTensor::CKKSTensor(const shared_ptr<const CKKSTensor>& tensor) {
     this->_shape = tensor->shape();
     this->_data = tensor->data();
     this->_batch_size = tensor->_batch_size;
+    this->_id = tensor->id();
 }
 
 Ciphertext CKKSTensor::encrypt(const shared_ptr<TenSEALContext>& ctx,
@@ -511,6 +512,7 @@ void CKKSTensor::clear() {
     this->_data = vector<Ciphertext>();
     this->_batch_size = optional<double>();
     this->_init_scale = 0;
+    this->_id = 0;
 }
 
 void CKKSTensor::load_proto(const CKKSTensorProto& tensor_proto) {
@@ -529,6 +531,7 @@ void CKKSTensor::load_proto(const CKKSTensorProto& tensor_proto) {
     this->_init_scale = tensor_proto.scale();
     if (tensor_proto.batch_size())
         this->_batch_size = tensor_proto.batch_size();
+    this->_id = tensor_proto.id();
 }
 
 CKKSTensorProto CKKSTensor::save_proto() const {
@@ -542,6 +545,7 @@ CKKSTensorProto CKKSTensor::save_proto() const {
     }
     buffer.set_scale(this->_init_scale);
     if (this->_batch_size) buffer.set_batch_size(*this->_batch_size);
+    buffer.set_id(this->_id);
 
     return buffer;
 }

--- a/tenseal/cpp/tensors/ckksvector.cpp
+++ b/tenseal/cpp/tensors/ckksvector.cpp
@@ -43,6 +43,7 @@ CKKSVector::CKKSVector(const shared_ptr<const CKKSVector>& vec) {
     this->_init_scale = vec->scale();
     this->_size = vec->size();
     this->_ciphertext = vec->ciphertext();
+    this->_id = vec->id();
 }
 
 Ciphertext CKKSVector::encrypt(shared_ptr<TenSEALContext> context, double scale,
@@ -448,6 +449,7 @@ void CKKSVector::load_proto(const CKKSVectorProto& vec) {
     this->_ciphertext = SEALDeserialize<Ciphertext>(
         *this->tenseal_context()->seal_context(), vec.ciphertext());
     this->_init_scale = vec.scale();
+    this->_id = vec.id();
 }
 
 CKKSVectorProto CKKSVector::save_proto() const {
@@ -456,6 +458,7 @@ CKKSVectorProto CKKSVector::save_proto() const {
     *buffer.mutable_ciphertext() = SEALSerialize<Ciphertext>(this->_ciphertext);
     buffer.set_size(static_cast<int>(this->_size));
     buffer.set_scale(this->_init_scale);
+    buffer.set_id(this->_id);
 
     return buffer;
 }

--- a/tenseal/cpp/tensors/encrypted_tensor.h
+++ b/tenseal/cpp/tensors/encrypted_tensor.h
@@ -250,8 +250,8 @@ class EncryptedTensor {
         }
     }
 
-    uint64_t id() const{return _id;}
-    void id(uint64_t new_id) {_id = new_id;}
+    uint64_t id() const { return _id; }
+    void id(uint64_t new_id) { _id = new_id; }
 
     virtual ~EncryptedTensor(){};
 

--- a/tenseal/cpp/tensors/encrypted_tensor.h
+++ b/tenseal/cpp/tensors/encrypted_tensor.h
@@ -249,9 +249,14 @@ class EncryptedTensor {
                 other, ct.parms_id());
         }
     }
+
+    uint64_t id() const{return _id;}
+    void id(uint64_t new_id) {_id = new_id;}
+
     virtual ~EncryptedTensor(){};
 
    protected:
+    uint64_t _id = 0;
     shared_ptr<TenSEALContext> _context;
 
    private:

--- a/tenseal/proto/tensealcontext.proto
+++ b/tenseal/proto/tensealcontext.proto
@@ -35,4 +35,6 @@ message TenSEALContextProto {
     TenSEALPublicProto public_context = 2;
     // Optional private members
     TenSEALPrivateProto private_context = 3;
+    // ID
+    uint64 id = 4;
 }

--- a/tenseal/proto/tensors.proto
+++ b/tenseal/proto/tensors.proto
@@ -7,6 +7,8 @@ message BFVVectorProto {
     uint32 size = 1;
     // The serialized ciphertext
     bytes ciphertext = 2;
+    // ID
+    uint64 id = 3;
 };
 
 //CKKSVector parameters
@@ -17,6 +19,8 @@ message CKKSVectorProto {
     bytes ciphertext = 2;
     // Scale value
     double scale = 3;
+    // ID
+    uint64 id = 4;
 };
 
 //CKKSTensor parameters
@@ -29,4 +33,6 @@ message CKKSTensorProto {
     double scale = 3;
     // Optional batch size. Exists only if batching is enabled
     uint32 batch_size = 4;
+    // ID
+    uint64 id = 5;
 };

--- a/tests/cpp/tensealcontext_test.cpp
+++ b/tests/cpp/tensealcontext_test.cpp
@@ -36,11 +36,14 @@ TEST_F(TenSEALContextTest, TestSerialization) {
     auto ctx =
         TenSEALContext::Create(scheme_type::ckks, 8192, -1, {60, 40, 40, 60});
     ctx->generate_galois_keys();
+    ctx->id(1234);
 
     auto buff = ctx->save();
     auto recreated_ctx = TenSEALContext::Create(buff);
 
     ASSERT_TRUE(recreated_ctx != nullptr);
+    ASSERT_EQ(recreated_ctx->id(), 1234);
+
     auto &orig_pubkey = ctx->public_key()->data().dyn_array();
     auto &serial_pubkey = recreated_ctx->public_key()->data().dyn_array();
     for (size_t idx = 0; idx < orig_pubkey.size(); ++idx) {

--- a/tests/cpp/tensors/bfvvector_test.cpp
+++ b/tests/cpp/tensors/bfvvector_test.cpp
@@ -24,6 +24,7 @@ TEST_P(BFVVectorTest, TestCreateBFV) {
     ASSERT_TRUE(ctx != nullptr);
 
     auto l = BFVVector::Create(ctx, vector<int64_t>({1, 2, 3}));
+    l->id(1234);
 
     if (should_serialize_first) {
         l = duplicate(l);
@@ -31,6 +32,7 @@ TEST_P(BFVVectorTest, TestCreateBFV) {
 
     ASSERT_EQ(l->size(), 3);
     ASSERT_EQ(l->ciphertext_size(), 2);
+    ASSERT_EQ(l->id(), 1234);
 }
 
 TEST_P(BFVVectorTest, TestBFVAdd) {

--- a/tests/cpp/tensors/ckkstensor_test.cpp
+++ b/tests/cpp/tensors/ckkstensor_test.cpp
@@ -37,12 +37,14 @@ TEST_P(CKKSTensorTest, TestCreateCKKSNoBatching) {
 
     auto l = CKKSTensor::Create(ctx, std::vector<double>{1, 2, 3},
                                 std::pow(2, 40), false);
+    l->id(1234);
 
     if (should_serialize_first) {
         l = duplicate(l);
     }
 
     ASSERT_EQ(l->data().size(), 3);
+    ASSERT_EQ(l->id(), 1234);
 }
 
 TEST_P(CKKSTensorTest, TestDecryptCKKSNoBatching) {

--- a/tests/cpp/tensors/ckksvector_test.cpp
+++ b/tests/cpp/tensors/ckksvector_test.cpp
@@ -36,12 +36,14 @@ TEST_P(CKKSVectorTest, TestCreateCKKS) {
     ASSERT_TRUE(ctx != nullptr);
 
     auto l = CKKSVector::Create(ctx, std::vector<double>{1, 2, 3}, 1);
+    l->id(1234);
 
     if (should_serialize_first) {
         l = duplicate(l);
     }
 
     ASSERT_EQ(l->ciphertext_size(), 2);
+    ASSERT_EQ(l->id(), 1234);
 }
 
 TEST_F(CKKSVectorTest, TestCreateCKKSFail) {

--- a/tests/python/tenseal/tensors/test_serialization.py
+++ b/tests/python/tenseal/tensors/test_serialization.py
@@ -59,6 +59,17 @@ def recreate_bfv(vec):
 
 
 @pytest.mark.parametrize(
+    "duplicate", [deep_copy, simple_copy, internal_copy, recreate_ckks,],
+)
+def test_ckks_vector_id(duplicate):
+    context = ckks_context()
+    orig = ts.ckks_vector(context, [1, 2, 3, 4])
+    orig.id = 1234
+    duplicated = duplicate(orig)
+    assert duplicated.id == 1234
+
+
+@pytest.mark.parametrize(
     "plain_vec", [[0], [-1], [1], [21, 81, 90], [-73, -81, -90], [-11, 82, -43, 52]]
 )
 @pytest.mark.parametrize(
@@ -275,6 +286,17 @@ def test_mul_without_global_scale(vec1, vec2, precision, duplicate):
         decrypted_result, expected, precision
     ), "Multiplication of vectors is incorrect."
     assert _almost_equal(first_vec.decrypt(), vec1, precision), "Something went wrong in memory."
+
+
+@pytest.mark.parametrize(
+    "duplicate", [deep_copy, simple_copy, internal_copy, recreate_bfv,],
+)
+def test_bfv_vector_id(duplicate):
+    context = bfv_context()
+    orig = ts.bfv_vector(context, [1, 2, 3, 4])
+    orig.id = 1234
+    duplicated = duplicate(orig)
+    assert duplicated.id == 1234
 
 
 @pytest.mark.parametrize(
@@ -560,3 +582,15 @@ def test_ckks_tensor_sanity(plain_vec, precision, duplicate):
     decrypted = ts.tolist(ckks_tensor.decrypt())
 
     assert _almost_equal(decrypted, plain_vec, precision), "Decryption of tensor is incorrect"
+
+
+@pytest.mark.parametrize(
+    "duplicate", [deep_copy, simple_copy, internal_copy, recreate_ckks_tensor,],
+)
+def test_ckks_tensor_id(duplicate):
+    context = ckks_context()
+    plain_tensor = ts.plain_tensor([1, 2, 3, 4])
+    orig = ts.ckks_tensor(context, plain_tensor)
+    orig.id = 1234
+    duplicated = duplicate(orig)
+    assert duplicated.id == 1234

--- a/tests/python/tenseal/test_serialization.py
+++ b/tests/python/tenseal/test_serialization.py
@@ -27,6 +27,14 @@ def recreate(ctx):
 
 
 @pytest.mark.parametrize("duplicate", [deep_copy, simple_copy, internal_copy, recreate,])
+def test_context_id(duplicate):
+    orig_context = ctx()
+    orig_context.id = 1234
+    context = duplicate(orig_context)
+    assert context.id == 1234
+
+
+@pytest.mark.parametrize("duplicate", [deep_copy, simple_copy, internal_copy, recreate,])
 def test_context_recreation(duplicate):
     orig_context = ctx()
     context = duplicate(orig_context)


### PR DESCRIPTION
## Description
We need an ID field in the tensors and in the context. That field should be available in the protobuffers as well.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
