### PR TITLE
Parameter what's stored while serializing the context

### DIFF
--- a/tenseal/binding.cpp
+++ b/tenseal/binding.cpp
@@ -638,7 +638,12 @@ PYBIND11_MODULE(_tenseal_cpp, m) {
                  &TenSEALContext::generate_relin_keys),
              "Generate Relinearization keys using the secret key")
         .def("serialize",
-             [](const TenSEALContext &obj) { return py::bytes(obj.save()); })
+             [](const TenSEALContext &obj, bool save_public_key,
+                bool save_secret_key, bool save_galois_keys,
+                bool save_relin_keys) {
+                 return py::bytes(obj.save(save_public_key, save_secret_key,
+                                           save_galois_keys, save_relin_keys));
+             })
         .def_static("deserialize",
                     py::overload_cast<const std::string &, optional<size_t>>(
                         &TenSEALContext::Create),

--- a/tenseal/cpp/context/tensealcontext.cpp
+++ b/tenseal/cpp/context/tensealcontext.cpp
@@ -45,8 +45,9 @@ void TenSEALContext::base_setup(EncryptionParameters parms) {
 }
 
 void TenSEALContext::keys_setup_public_key(optional<PublicKey> public_key,
-                                           optional<SecretKey> secret_key) {
-    if (!public_key && !secret_key) {
+                                           optional<SecretKey> secret_key,
+                                           bool generate_key) {
+    if (!public_key && !secret_key && generate_key) {
         KeyGenerator keygen = KeyGenerator(*this->_context);
 
         PublicKey pk;
@@ -91,7 +92,8 @@ void TenSEALContext::keys_setup(encryption_type enc_type,
     this->_encryption_type = enc_type;
     switch (enc_type) {
         case encryption_type::asymmetric: {
-            this->keys_setup_public_key(public_key, secret_key);
+            this->keys_setup_public_key(public_key, secret_key,
+                                        generate_secret);
             break;
         }
         case encryption_type::symmetric: {

--- a/tenseal/cpp/context/tensealcontext.cpp
+++ b/tenseal/cpp/context/tensealcontext.cpp
@@ -18,10 +18,6 @@ TenSEALContext::TenSEALContext(EncryptionParameters parms,
     this->keys_setup(encryption_type);
 }
 
-TenSEALContext::TenSEALContext(istream& stream, optional<size_t> n_threads) {
-    this->dispatcher_setup(n_threads);
-    this->load(stream);
-}
 TenSEALContext::TenSEALContext(const std::string& input,
                                optional<size_t> n_threads) {
     this->dispatcher_setup(n_threads);
@@ -134,11 +130,6 @@ shared_ptr<TenSEALContext> TenSEALContext::Create(
 
     return shared_ptr<TenSEALContext>(
         new TenSEALContext(parms, encryption_type, n_threads));
-}
-
-shared_ptr<TenSEALContext> TenSEALContext::Create(istream& stream,
-                                                  optional<size_t> n_threads) {
-    return shared_ptr<TenSEALContext>(new TenSEALContext(stream, n_threads));
 }
 
 shared_ptr<TenSEALContext> TenSEALContext::Create(const std::string& input,
@@ -399,8 +390,11 @@ void TenSEALContext::load_proto_public_key(const TenSEALContextProto& buffer) {
         this->global_scale(buffer.public_context().scale());
     }
 
-    auto public_key = SEALDeserialize<PublicKey>(
-        *this->_context, buffer.public_context().public_key());
+    optional<PublicKey> public_key = {};
+    if (!buffer.public_context().public_key().empty()) {
+        public_key = SEALDeserialize<PublicKey>(
+            *this->_context, buffer.public_context().public_key());
+    }
 
     if (!buffer.has_private_context()) {
         this->keys_setup(encryption_type::asymmetric, public_key);
@@ -413,8 +407,11 @@ void TenSEALContext::load_proto_public_key(const TenSEALContextProto& buffer) {
         return;
     }
 
-    auto secret_key = SEALDeserialize<SecretKey>(
-        *this->_context, buffer.private_context().secret_key());
+    optional<SecretKey> secret_key = {};
+    if (!buffer.private_context().secret_key().empty()) {
+        secret_key = SEALDeserialize<SecretKey>(
+            *this->_context, buffer.private_context().secret_key());
+    }
     this->keys_setup(encryption_type::asymmetric, public_key, secret_key,
                      buffer.private_context().relin_keys_generated(),
                      buffer.private_context().galois_keys_generated());
@@ -428,11 +425,21 @@ void TenSEALContext::load_proto_symmetric(const TenSEALContextProto& buffer) {
         this->global_scale(buffer.public_context().scale());
     }
 
-    auto secret_key = SEALDeserialize<SecretKey>(
-        *this->_context, buffer.private_context().secret_key());
-    this->keys_setup(encryption_type::symmetric, {}, secret_key,
-                     buffer.private_context().relin_keys_generated(),
-                     buffer.private_context().galois_keys_generated());
+    if (!buffer.private_context().secret_key().empty()) {
+        auto secret_key = SEALDeserialize<SecretKey>(
+            *this->_context, buffer.private_context().secret_key());
+        this->keys_setup(encryption_type::symmetric, {}, secret_key,
+                         buffer.private_context().relin_keys_generated(),
+                         buffer.private_context().galois_keys_generated());
+    } else {
+        this->keys_setup(encryption_type::symmetric);
+        if (!buffer.public_context().galois_keys().empty()) {
+            this->generate_galois_keys(buffer.public_context().galois_keys());
+        }
+        if (!buffer.public_context().relin_keys().empty()) {
+            this->generate_relin_keys(buffer.public_context().relin_keys());
+        }
+    }
 }
 
 void TenSEALContext::load_proto(const TenSEALContextProto& buffer) {
@@ -447,7 +454,9 @@ void TenSEALContext::load_proto(const TenSEALContextProto& buffer) {
     }
 }
 
-TenSEALContextProto TenSEALContext::save_proto_public_key() const {
+TenSEALContextProto TenSEALContext::save_proto_public_key(
+    bool save_public_key, bool save_secret_key, bool save_galois_keys,
+    bool save_relin_keys) const {
     TenSEALContextProto buffer;
     buffer.set_encryption_type(to_underlying(this->_encryption_type));
 
@@ -456,16 +465,18 @@ TenSEALContextProto TenSEALContext::save_proto_public_key() const {
 
     TenSEALPublicProto public_buffer;
     public_buffer.set_auto_flags(this->_auto_flags);
-    *public_buffer.mutable_public_key() =
-        SEALSerialize<PublicKey>(*this->public_key());
-
     public_buffer.set_scale(this->safe_global_scale());
 
+    if (save_public_key) {
+        *public_buffer.mutable_public_key() =
+            SEALSerialize<PublicKey>(*this->public_key());
+    }
+
     if (this->is_public()) {
-        if (this->_galois_keys)
+        if (save_galois_keys && this->_galois_keys)
             *public_buffer.mutable_galois_keys() =
                 SEALSerialize<GaloisKeys>(*this->_galois_keys);
-        if (this->_relin_keys)
+        if (save_relin_keys && this->_relin_keys)
             *public_buffer.mutable_relin_keys() =
                 SEALSerialize<RelinKeys>(*this->_relin_keys);
     }
@@ -477,8 +488,11 @@ TenSEALContextProto TenSEALContext::save_proto_public_key() const {
     }
 
     TenSEALPrivateProto private_buffer;
-    *private_buffer.mutable_secret_key() =
-        SEALSerialize<SecretKey>(*this->secret_key());
+
+    if (save_secret_key) {
+        *private_buffer.mutable_secret_key() =
+            SEALSerialize<SecretKey>(*this->secret_key());
+    }
     private_buffer.set_galois_keys_generated(this->_galois_keys != nullptr);
     private_buffer.set_relin_keys_generated(this->_relin_keys != nullptr);
 
@@ -486,7 +500,9 @@ TenSEALContextProto TenSEALContext::save_proto_public_key() const {
     return buffer;
 }
 
-TenSEALContextProto TenSEALContext::save_proto_symmetric() const {
+TenSEALContextProto TenSEALContext::save_proto_symmetric(
+    bool save_public_key, bool save_secret_key, bool save_galois_keys,
+    bool save_relin_keys) const {
     TenSEALContextProto buffer;
     buffer.set_encryption_type(to_underlying(this->_encryption_type));
 
@@ -496,47 +512,54 @@ TenSEALContextProto TenSEALContext::save_proto_symmetric() const {
     TenSEALPublicProto public_buffer;
     public_buffer.set_auto_flags(this->_auto_flags);
     public_buffer.set_scale(this->safe_global_scale());
+
+    if (!save_secret_key) {
+        if (save_galois_keys && this->_galois_keys)
+            *public_buffer.mutable_galois_keys() =
+                SEALSerialize<GaloisKeys>(*this->_galois_keys);
+        if (save_relin_keys && this->_relin_keys)
+            *public_buffer.mutable_relin_keys() =
+                SEALSerialize<RelinKeys>(*this->_relin_keys);
+    }
+
     *buffer.mutable_public_context() = public_buffer;
 
     TenSEALPrivateProto private_buffer;
-    *private_buffer.mutable_secret_key() =
-        SEALSerialize<SecretKey>(*this->secret_key());
-    private_buffer.set_galois_keys_generated(this->_galois_keys != nullptr);
-    private_buffer.set_relin_keys_generated(this->_relin_keys != nullptr);
+    if (save_secret_key) {
+        *private_buffer.mutable_secret_key() =
+            SEALSerialize<SecretKey>(*this->secret_key());
+        private_buffer.set_galois_keys_generated(this->_galois_keys != nullptr);
+        private_buffer.set_relin_keys_generated(this->_relin_keys != nullptr);
+    }
 
     *buffer.mutable_private_context() = private_buffer;
     return buffer;
 }
 
-TenSEALContextProto TenSEALContext::save_proto() const {
+TenSEALContextProto TenSEALContext::save_proto(bool save_public_key,
+                                               bool save_secret_key,
+                                               bool save_galois_keys,
+                                               bool save_relin_keys) const {
     switch (this->_encryption_type) {
         case encryption_type::asymmetric:
-            return this->save_proto_public_key();
+            return this->save_proto_public_key(save_public_key, save_secret_key,
+                                               save_galois_keys,
+                                               save_relin_keys);
         case encryption_type::symmetric:
-            return this->save_proto_symmetric();
+            return this->save_proto_symmetric(save_public_key, save_secret_key,
+                                              save_galois_keys,
+                                              save_relin_keys);
         default:
             throw invalid_argument("encryption type not support for serialize");
     }
 }
 
 std::shared_ptr<TenSEALContext> TenSEALContext::copy() const {
-    TenSEALContextProto buffer = this->save_proto();
+    TenSEALContextProto buffer =
+        this->save_proto(/*save_public_key=*/true, /*save_secret_key=*/true,
+                         /*save_galois_keys=*/true, /*save_relin_keys=*/true);
     return shared_ptr<TenSEALContext>(
         new TenSEALContext(buffer, this->_threads));
-}
-
-void TenSEALContext::load(std::istream& stream) {
-    TenSEALContextProto buffer;
-    if (!buffer.ParseFromIstream(&stream)) {
-        throw invalid_argument("failed to parse stream");
-    }
-
-    this->load_proto(buffer);
-}
-
-bool TenSEALContext::save(std::ostream& stream) const {
-    TenSEALContextProto buffer = this->save_proto();
-    return buffer.SerializeToOstream(&stream);
 }
 
 void TenSEALContext::load(const std::string& input) {
@@ -547,8 +570,11 @@ void TenSEALContext::load(const std::string& input) {
     this->load_proto(buffer);
 }
 
-std::string TenSEALContext::save() const {
-    TenSEALContextProto buffer = this->save_proto();
+std::string TenSEALContext::save(bool save_public_key, bool save_secret_key,
+                                 bool save_galois_keys,
+                                 bool save_relin_keys) const {
+    TenSEALContextProto buffer = this->save_proto(
+        save_public_key, save_secret_key, save_galois_keys, save_relin_keys);
     std::string output;
     output.resize(proto_bytes_size(buffer));
 

--- a/tenseal/cpp/context/tensealcontext.h
+++ b/tenseal/cpp/context/tensealcontext.h
@@ -300,7 +300,8 @@ class TenSEALContext {
                     bool generate_galois_keys = false,
                     bool generate_secret_key = true);
     void keys_setup_public_key(optional<PublicKey> public_key = {},
-                               optional<SecretKey> secret_key = {});
+                               optional<SecretKey> secret_key = {},
+                               bool generate_secret_key = true);
     void keys_setup_symmetric(optional<SecretKey> secret_key = {},
                               bool generate_secret_key = true);
     /**

--- a/tenseal/cpp/context/tensealcontext.h
+++ b/tenseal/cpp/context/tensealcontext.h
@@ -297,10 +297,12 @@ class TenSEALContext {
                     optional<PublicKey> public_key = {},
                     optional<SecretKey> secret_key = {},
                     bool generate_relin_keys = true,
-                    bool generate_galois_keys = false);
+                    bool generate_galois_keys = false,
+                    bool generate_secret_key = true);
     void keys_setup_public_key(optional<PublicKey> public_key = {},
                                optional<SecretKey> secret_key = {});
-    void keys_setup_symmetric(optional<SecretKey> secret_key = {});
+    void keys_setup_symmetric(optional<SecretKey> secret_key = {},
+                              bool generate_secret_key = true);
     /**
      * Load/Save a protobuffer for the current context.
      **/

--- a/tenseal/cpp/context/tensealcontext.h
+++ b/tenseal/cpp/context/tensealcontext.h
@@ -212,27 +212,16 @@ class TenSEALContext {
     bool auto_rescale() const;
     bool auto_mod_switch() const;
     /**
-     * Read a serialized protobuffer from an input stream and populate the
-     *current context.
-     * @param[in] input stream.
-     **/
-    void load(std::istream& stream);
-    /**
      * Populate the current context from a serialized protobuffer.
      * @param[in] input serialized protobuffer.
      **/
     void load(const std::string& input);
     /**
-     * Save the current context to a serialized protobuffer and write it to an
-     *output stream.
-     * @param[in] output stream.
-     **/
-    bool save(std::ostream& stream) const;
-    /**
      * Save the current context to a serialized protobuffer.
      * @returns serialized protobuffer.
      **/
-    std::string save() const;
+    std::string save(bool save_public_key, bool save_secret_key,
+                     bool save_galois_keys, bool save_relin_keys) const;
     /**
      * @returns a deepcopy of the current context.
      **/
@@ -241,7 +230,9 @@ class TenSEALContext {
      * Load/Save a protobuffer for the current context.
      **/
     void load_proto(const TenSEALContextProto& buffer);
-    TenSEALContextProto save_proto() const;
+    TenSEALContextProto save_proto(bool save_public_key, bool save_secret_key,
+                                   bool save_galois_keys,
+                                   bool save_relin_keys) const;
     /**
      * @returns the encryption params of the current context.
      **/
@@ -315,8 +306,14 @@ class TenSEALContext {
      **/
     void load_proto_public_key(const TenSEALContextProto& buffer);
     void load_proto_symmetric(const TenSEALContextProto& buffer);
-    TenSEALContextProto save_proto_public_key() const;
-    TenSEALContextProto save_proto_symmetric() const;
+    TenSEALContextProto save_proto_public_key(bool save_public_key,
+                                              bool save_secret_key,
+                                              bool save_galois_keys,
+                                              bool save_relin_keys) const;
+    TenSEALContextProto save_proto_symmetric(bool save_public_key,
+                                             bool save_secret_key,
+                                             bool save_galois_keys,
+                                             bool save_relin_keys) const;
 };
 }  // namespace tenseal
 #endif

--- a/tenseal/cpp/tensors/bfvvector.cpp
+++ b/tenseal/cpp/tensors/bfvvector.cpp
@@ -356,7 +356,9 @@ shared_ptr<BFVVector> BFVVector::copy() const {
 shared_ptr<BFVVector> BFVVector::deepcopy() const {
     if (_lazy_buffer) return this->copy();
 
-    TenSEALContextProto ctx = this->tenseal_context()->save_proto();
+    TenSEALContextProto ctx = this->tenseal_context()->save_proto(
+        /*save_public_key=*/true, /*save_secret_key=*/true,
+        /*save_galois_keys=*/true, /*save_relin_keys=*/true);
     BFVVectorProto vec = this->save_proto();
     return BFVVector::Create(ctx, vec);
 }

--- a/tenseal/cpp/tensors/ckkstensor.cpp
+++ b/tenseal/cpp/tensors/ckkstensor.cpp
@@ -778,7 +778,9 @@ shared_ptr<CKKSTensor> CKKSTensor::copy() const {
 shared_ptr<CKKSTensor> CKKSTensor::deepcopy() const {
     if (_lazy_buffer) return this->copy();
 
-    TenSEALContextProto ctx = this->tenseal_context()->save_proto();
+    TenSEALContextProto ctx = this->tenseal_context()->save_proto(
+        /*save_public_key=*/true, /*save_secret_key=*/true,
+        /*save_galois_keys=*/true, /*save_relin_keys=*/true);
     CKKSTensorProto vec = this->save_proto();
     return CKKSTensor::Create(ctx, vec);
 }

--- a/tenseal/cpp/tensors/ckksvector.cpp
+++ b/tenseal/cpp/tensors/ckksvector.cpp
@@ -496,7 +496,9 @@ shared_ptr<CKKSVector> CKKSVector::copy() const {
 shared_ptr<CKKSVector> CKKSVector::deepcopy() const {
     if (_lazy_buffer) return this->copy();
 
-    TenSEALContextProto ctx = this->tenseal_context()->save_proto();
+    TenSEALContextProto ctx = this->tenseal_context()->save_proto(
+        /*save_public_key=*/true, /*save_secret_key=*/true,
+        /*save_galois_keys=*/true, /*save_relin_keys=*/true);
     CKKSVectorProto vec = this->save_proto();
     return CKKSVector::Create(ctx, vec);
 }

--- a/tenseal/enc_context.py
+++ b/tenseal/enc_context.py
@@ -177,7 +177,9 @@ class Context:
         save_relin_keys: bool = True,
     ) -> bytes:
         """Serialize the context into a stream of bytes."""
-        return self.data.serialize()
+        return self.data.serialize(
+            save_public_key, save_secret_key, save_galois_keys, save_relin_keys
+        )
 
     @property
     def global_scale(self) -> float:

--- a/tenseal/enc_context.py
+++ b/tenseal/enc_context.py
@@ -172,7 +172,7 @@ class Context:
     def serialize(
         self,
         save_public_key: bool = True,
-        save_secret_key: bool = True,
+        save_secret_key: bool = False,
         save_galois_keys: bool = True,
         save_relin_keys: bool = True,
     ) -> bytes:

--- a/tenseal/enc_context.py
+++ b/tenseal/enc_context.py
@@ -169,7 +169,13 @@ class Context:
             return cls._wrap(ts._ts_cpp.TenSEALContext.deserialize(data, n_threads))
         return cls._wrap(ts._ts_cpp.TenSEALContext.deserialize(data))
 
-    def serialize(self) -> bytes:
+    def serialize(
+        self,
+        save_public_key: bool = True,
+        save_secret_key: bool = True,
+        save_galois_keys: bool = True,
+        save_relin_keys: bool = True,
+    ) -> bytes:
         """Serialize the context into a stream of bytes."""
         return self.data.serialize()
 

--- a/tests/cpp/tensealcontext_test.cpp
+++ b/tests/cpp/tensealcontext_test.cpp
@@ -303,6 +303,20 @@ TEST_P(TenSEALContextTest, TestSerializationCKKSDropPublicKey) {
         ASSERT_FALSE(des->public_key() != nullptr);
     else
         EXPECT_THROW(des->public_key(), std::exception);
+
+    // Drop public key and secret key
+    buff = ctx->save(/*save_public_key=*/false, /*save_secret_key=*/false,
+                     /*save_galois_keys=*/true, /*save_relin_keys=*/true);
+    des = TenSEALContext::Create(buff);
+
+    ASSERT_TRUE(des->has_relin_keys());
+    ASSERT_TRUE(des->has_galois_key());
+    ASSERT_FALSE(des->has_secret_key());
+
+    if (enc_type == encryption_type::asymmetric)
+        ASSERT_FALSE(des->public_key() != nullptr);
+    else
+        EXPECT_THROW(des->public_key(), std::exception);
 }
 
 TEST_P(TenSEALContextTest, TestSerializationCKKSDropSecretKey) {

--- a/tests/cpp/tensealcontext_test.cpp
+++ b/tests/cpp/tensealcontext_test.cpp
@@ -181,6 +181,161 @@ TEST_P(TenSEALContextTest, TestCreateCKKSPublic) {
     ASSERT_FALSE(ctx->is_private());
 }
 
+TEST_P(TenSEALContextTest, TestSerializationCKKSDropRelinKeys) {
+    auto enc_type = get<1>(GetParam());
+
+    auto ctx = TenSEALContext::Create(scheme_type::ckks, 8192, -1,
+                                      {60, 40, 40, 60}, enc_type);
+
+    ctx->generate_galois_keys();
+
+    ASSERT_TRUE(ctx->has_relin_keys());
+    ASSERT_TRUE(ctx->has_galois_key());
+    ASSERT_TRUE(ctx->has_secret_key());
+
+    if (enc_type == encryption_type::asymmetric)
+        ASSERT_TRUE(ctx->public_key() != nullptr);
+    else
+        EXPECT_THROW(ctx->public_key(), std::exception);
+
+    // Drop Relin keys
+    auto buff = ctx->save(/*save_public_key=*/true, /*save_secret_key=*/true,
+                          /*save_galois_keys=*/true, /*save_relin_keys=*/false);
+    auto des = TenSEALContext::Create(buff);
+
+    ASSERT_FALSE(des->has_relin_keys());
+    ASSERT_TRUE(des->has_galois_key());
+    ASSERT_TRUE(des->has_secret_key());
+
+    if (enc_type == encryption_type::asymmetric)
+        ASSERT_TRUE(des->public_key() != nullptr);
+    else
+        EXPECT_THROW(des->public_key(), std::exception);
+
+    // Drop Relin keys and secret key
+    buff = ctx->save(/*save_public_key=*/true, /*save_secret_key=*/false,
+                     /*save_galois_keys=*/true, /*save_relin_keys=*/false);
+    des = TenSEALContext::Create(buff);
+
+    ASSERT_FALSE(des->has_secret_key());
+    ASSERT_FALSE(des->has_relin_keys());
+    ASSERT_TRUE(des->has_galois_key());
+
+    if (enc_type == encryption_type::asymmetric)
+        ASSERT_TRUE(des->public_key() != nullptr);
+    else
+        EXPECT_THROW(des->public_key(), std::exception);
+}
+
+TEST_P(TenSEALContextTest, TestSerializationCKKSDropGaloisKeys) {
+    auto enc_type = get<1>(GetParam());
+
+    auto ctx = TenSEALContext::Create(scheme_type::ckks, 8192, -1,
+                                      {60, 40, 40, 60}, enc_type);
+
+    ctx->generate_galois_keys();
+
+    ASSERT_TRUE(ctx->has_relin_keys());
+    ASSERT_TRUE(ctx->has_galois_key());
+    ASSERT_TRUE(ctx->has_secret_key());
+
+    if (enc_type == encryption_type::asymmetric)
+        ASSERT_TRUE(ctx->public_key() != nullptr);
+    else
+        EXPECT_THROW(ctx->public_key(), std::exception);
+
+    // Drop Galois keys
+    auto buff = ctx->save(/*save_public_key=*/true, /*save_secret_key=*/true,
+                          /*save_galois_keys=*/false, /*save_relin_keys=*/true);
+    auto des = TenSEALContext::Create(buff);
+
+    ASSERT_TRUE(des->has_relin_keys());
+    ASSERT_FALSE(des->has_galois_key());
+    ASSERT_TRUE(des->has_secret_key());
+
+    if (enc_type == encryption_type::asymmetric)
+        ASSERT_TRUE(des->public_key() != nullptr);
+    else
+        EXPECT_THROW(des->public_key(), std::exception);
+
+    // Drop Galois keys and secret key
+    buff = ctx->save(/*save_public_key=*/true, /*save_secret_key=*/false,
+                     /*save_galois_keys=*/false, /*save_relin_keys=*/true);
+    des = TenSEALContext::Create(buff);
+
+    ASSERT_TRUE(des->has_relin_keys());
+    ASSERT_FALSE(des->has_galois_key());
+    ASSERT_FALSE(des->has_secret_key());
+
+    if (enc_type == encryption_type::asymmetric)
+        ASSERT_TRUE(des->public_key() != nullptr);
+    else
+        EXPECT_THROW(des->public_key(), std::exception);
+}
+
+TEST_P(TenSEALContextTest, TestSerializationCKKSDropPublicKey) {
+    auto enc_type = get<1>(GetParam());
+
+    auto ctx = TenSEALContext::Create(scheme_type::ckks, 8192, -1,
+                                      {60, 40, 40, 60}, enc_type);
+
+    ctx->generate_galois_keys();
+
+    ASSERT_TRUE(ctx->has_relin_keys());
+    ASSERT_TRUE(ctx->has_galois_key());
+    ASSERT_TRUE(ctx->has_secret_key());
+
+    if (enc_type == encryption_type::asymmetric)
+        ASSERT_TRUE(ctx->public_key() != nullptr);
+    else
+        EXPECT_THROW(ctx->public_key(), std::exception);
+
+    // Drop public key
+    auto buff = ctx->save(/*save_public_key=*/false, /*save_secret_key=*/true,
+                          /*save_galois_keys=*/true, /*save_relin_keys=*/true);
+    auto des = TenSEALContext::Create(buff);
+
+    ASSERT_TRUE(des->has_relin_keys());
+    ASSERT_TRUE(des->has_galois_key());
+    ASSERT_TRUE(des->has_secret_key());
+
+    if (enc_type == encryption_type::asymmetric)
+        ASSERT_FALSE(des->public_key() != nullptr);
+    else
+        EXPECT_THROW(des->public_key(), std::exception);
+}
+
+TEST_P(TenSEALContextTest, TestSerializationCKKSDropSecretKey) {
+    auto enc_type = get<1>(GetParam());
+
+    auto ctx = TenSEALContext::Create(scheme_type::ckks, 8192, -1,
+                                      {60, 40, 40, 60}, enc_type);
+
+    ctx->generate_galois_keys();
+
+    ASSERT_TRUE(ctx->has_relin_keys());
+    ASSERT_TRUE(ctx->has_galois_key());
+    ASSERT_TRUE(ctx->has_secret_key());
+
+    if (enc_type == encryption_type::asymmetric)
+        ASSERT_TRUE(ctx->public_key() != nullptr);
+    else
+        EXPECT_THROW(ctx->public_key(), std::exception);
+
+    // Drop secret key
+    auto buff = ctx->save(/*save_public_key=*/true, /*save_secret_key=*/false,
+                          /*save_galois_keys=*/true, /*save_relin_keys=*/true);
+    auto des = TenSEALContext::Create(buff);
+    ASSERT_TRUE(des->has_relin_keys());
+    ASSERT_TRUE(des->has_galois_key());
+    ASSERT_FALSE(des->has_secret_key());
+
+    if (enc_type == encryption_type::asymmetric)
+        ASSERT_TRUE(des->public_key() != nullptr);
+    else
+        EXPECT_THROW(des->public_key(), std::exception);
+}
+
 TEST_F(TenSEALContextTest, TestContextRegressionRecreateGaloisCrash) {
     EncryptionParameters parameters(scheme_type::ckks);
     parameters.set_poly_modulus_degree(8192);

--- a/tests/cpp/tensealcontext_test.cpp
+++ b/tests/cpp/tensealcontext_test.cpp
@@ -7,6 +7,12 @@ namespace tenseal {
 
 using namespace ::testing;
 
+auto duplicate(const shared_ptr<TenSEALContext> &ctx) {
+    auto buff = ctx->save(/*save_public_key=*/true, /*save_secret_key=*/true,
+                          /*save_galois_keys=*/true, /*save_relin_keys=*/true);
+    return TenSEALContext::Create(buff);
+}
+
 class TenSEALContextTest : public TestWithParam<tuple<bool, encryption_type>> {
    protected:
     void SetUp() {}
@@ -25,9 +31,6 @@ TEST_P(TenSEALContextTest, TestCreateFail) {
                  std::exception);
 
     EXPECT_THROW(auto ctx = TenSEALContext::Create("invalid"), std::exception);
-
-    std::stringstream ss;
-    EXPECT_THROW(auto ctx = TenSEALContext::Create(ss), std::exception);
 }
 
 TEST_P(TenSEALContextTest, TestSerialization) {
@@ -36,8 +39,7 @@ TEST_P(TenSEALContextTest, TestSerialization) {
                                       {60, 40, 40, 60}, enc_type);
     ctx->generate_galois_keys();
 
-    auto buff = ctx->save();
-    auto recreated_ctx = TenSEALContext::Create(buff);
+    auto recreated_ctx = duplicate(ctx);
 
     ASSERT_TRUE(recreated_ctx != nullptr);
     if (enc_type == encryption_type::asymmetric) {
@@ -85,8 +87,7 @@ TEST_P(TenSEALContextTest, TestCreateBFV) {
         TenSEALContext::Create(scheme_type::bfv, 8192, 1032193, {}, enc_type);
 
     if (should_serialize_first) {
-        auto buff = ctx->save();
-        ctx = TenSEALContext::Create(buff);
+        ctx = duplicate(ctx);
     }
 
     ASSERT_TRUE(ctx != nullptr);
@@ -117,8 +118,7 @@ TEST_P(TenSEALContextTest, TestCreateBFVPublic) {
     }
 
     if (should_serialize_first) {
-        auto buff = ctx->save();
-        ctx = TenSEALContext::Create(buff);
+        ctx = duplicate(ctx);
     }
 
     EXPECT_THROW(ctx->galois_keys(), std::exception);
@@ -139,8 +139,7 @@ TEST_P(TenSEALContextTest, TestCreateCKKS) {
                                       {60, 40, 40, 60}, enc_type);
 
     if (should_serialize_first) {
-        auto buff = ctx->save();
-        ctx = TenSEALContext::Create(buff);
+        ctx = duplicate(ctx);
     }
 
     ASSERT_TRUE(ctx != nullptr);
@@ -171,8 +170,7 @@ TEST_P(TenSEALContextTest, TestCreateCKKSPublic) {
     }
 
     if (should_serialize_first) {
-        auto buff = ctx->save();
-        ctx = TenSEALContext::Create(buff);
+        ctx = duplicate(ctx);
     }
 
     ASSERT_TRUE(ctx != nullptr);

--- a/tests/python/tenseal/test_serialization.py
+++ b/tests/python/tenseal/test_serialization.py
@@ -23,7 +23,7 @@ def internal_copy(ctx):
 
 
 def recreate(ctx):
-    proto = ctx.serialize()
+    proto = ctx.serialize(save_secret_key=True)
     return ts.context_from(proto)
 
 
@@ -237,3 +237,154 @@ def test_sanity_keys_regeneration(duplicate, vec1, vec2, encryption_type):
     ), "Dot product of vectors is incorrect."
     assert almost_equal(first_vec.decrypt(), vec1, precision), "Something went wrong in memory."
     assert almost_equal(second_vec.decrypt(), vec2, precision), "Something went wrong in memory."
+
+
+@pytest.mark.parametrize(
+    "encryption_type", [ts.ENCRYPTION_TYPE.ASYMMETRIC, ts.ENCRYPTION_TYPE.SYMMETRIC]
+)
+def test_serialization_parameters_drop_relinkey(encryption_type):
+    orig_context = ctx(encryption_type)
+    orig_context.generate_galois_keys()
+
+    assert orig_context.has_relin_keys()
+    assert orig_context.has_galois_keys()
+    assert orig_context.has_secret_key()
+
+    if encryption_type is ts.ENCRYPTION_TYPE.ASYMMETRIC:
+        assert orig_context.has_public_key()
+
+    # drop relin keys
+    proto = orig_context.serialize(
+        save_public_key=True, save_secret_key=True, save_galois_keys=True, save_relin_keys=False
+    )
+    nctx = ts.context_from(proto)
+
+    assert not nctx.has_relin_keys()
+    assert nctx.has_galois_keys()
+    assert nctx.has_secret_key()
+
+    if encryption_type is ts.ENCRYPTION_TYPE.ASYMMETRIC:
+        assert nctx.has_public_key()
+
+    # drop relin keys and secret key
+    proto = orig_context.serialize(
+        save_public_key=True, save_secret_key=False, save_galois_keys=True, save_relin_keys=False
+    )
+    nctx = ts.context_from(proto)
+
+    assert not nctx.has_relin_keys()
+    assert nctx.has_galois_keys()
+    assert not nctx.has_secret_key()
+
+    if encryption_type is ts.ENCRYPTION_TYPE.ASYMMETRIC:
+        assert nctx.has_public_key()
+
+
+@pytest.mark.parametrize(
+    "encryption_type", [ts.ENCRYPTION_TYPE.ASYMMETRIC, ts.ENCRYPTION_TYPE.SYMMETRIC]
+)
+def test_serialization_parameters_drop_galoiskey(encryption_type):
+    orig_context = ctx(encryption_type)
+    orig_context.generate_galois_keys()
+
+    assert orig_context.has_relin_keys()
+    assert orig_context.has_galois_keys()
+    assert orig_context.has_secret_key()
+
+    if encryption_type is ts.ENCRYPTION_TYPE.ASYMMETRIC:
+        assert orig_context.has_public_key()
+
+    # drop galois keys
+    proto = orig_context.serialize(
+        save_public_key=True, save_secret_key=True, save_galois_keys=False, save_relin_keys=True
+    )
+    nctx = ts.context_from(proto)
+
+    assert nctx.has_relin_keys()
+    assert not nctx.has_galois_keys()
+    assert nctx.has_secret_key()
+
+    if encryption_type is ts.ENCRYPTION_TYPE.ASYMMETRIC:
+        assert nctx.has_public_key()
+
+    # drop galois keys and secret key
+    proto = orig_context.serialize(
+        save_public_key=True, save_secret_key=False, save_galois_keys=False, save_relin_keys=True
+    )
+    nctx = ts.context_from(proto)
+
+    assert nctx.has_relin_keys()
+    assert not nctx.has_galois_keys()
+    assert not nctx.has_secret_key()
+
+    if encryption_type is ts.ENCRYPTION_TYPE.ASYMMETRIC:
+        assert nctx.has_public_key()
+
+
+@pytest.mark.parametrize(
+    "encryption_type", [ts.ENCRYPTION_TYPE.ASYMMETRIC, ts.ENCRYPTION_TYPE.SYMMETRIC]
+)
+def test_serialization_parameters_drop_secretkey(encryption_type):
+    orig_context = ctx(encryption_type)
+    orig_context.generate_galois_keys()
+
+    assert orig_context.has_relin_keys()
+    assert orig_context.has_galois_keys()
+    assert orig_context.has_secret_key()
+
+    if encryption_type is ts.ENCRYPTION_TYPE.ASYMMETRIC:
+        assert orig_context.has_public_key()
+
+    # drop secret key
+    proto = orig_context.serialize(
+        save_public_key=True, save_secret_key=False, save_galois_keys=True, save_relin_keys=True
+    )
+    nctx = ts.context_from(proto)
+
+    assert nctx.has_relin_keys()
+    assert nctx.has_galois_keys()
+    assert not nctx.has_secret_key()
+
+    if encryption_type is ts.ENCRYPTION_TYPE.ASYMMETRIC:
+        assert nctx.has_public_key()
+
+
+@pytest.mark.parametrize(
+    "encryption_type", [ts.ENCRYPTION_TYPE.ASYMMETRIC, ts.ENCRYPTION_TYPE.SYMMETRIC]
+)
+def test_serialization_parameters_drop_publickey(encryption_type):
+    orig_context = ctx(encryption_type)
+    orig_context.generate_galois_keys()
+
+    assert orig_context.has_relin_keys()
+    assert orig_context.has_galois_keys()
+    assert orig_context.has_secret_key()
+
+    if encryption_type is ts.ENCRYPTION_TYPE.ASYMMETRIC:
+        assert orig_context.has_public_key()
+
+    # drop public key
+    proto = orig_context.serialize(
+        save_public_key=False, save_secret_key=True, save_galois_keys=True, save_relin_keys=True
+    )
+    nctx = ts.context_from(proto)
+
+    assert nctx.has_relin_keys()
+    assert nctx.has_galois_keys()
+    assert nctx.has_secret_key()
+
+    if encryption_type is ts.ENCRYPTION_TYPE.ASYMMETRIC:
+        assert not nctx.has_public_key()
+
+    # drop public key and secret key
+    proto = orig_context.serialize(
+        save_public_key=False, save_secret_key=False, save_galois_keys=True, save_relin_keys=True
+    )
+    nctx = ts.context_from(proto)
+
+    assert nctx.has_relin_keys()
+    assert nctx.has_galois_keys()
+    assert not nctx.has_secret_key()
+
+    if encryption_type is ts.ENCRYPTION_TYPE.ASYMMETRIC:
+        assert not nctx.has_public_key()


### PR DESCRIPTION
## Description
This PR introduces support for choosing which keys are serialized in the context.

fixes https://github.com/OpenMined/TenSEAL/issues/130
fixes https://github.com/OpenMined/TenSEAL/issues/191


## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
