### PR TITLE
Encryption with an empty context should throw an exception

### DIFF
--- a/tenseal/cpp/context/tensealcontext.cpp
+++ b/tenseal/cpp/context/tensealcontext.cpp
@@ -151,6 +151,9 @@ shared_ptr<TenSEALContext> TenSEALContext::Create(
 
 void TenSEALContext::encrypt(const Plaintext& plain,
                              Ciphertext& destination) const {
+    if (this->encryptor == nullptr)
+        throw invalid_argument("this context doesn't support encryption");
+
     switch (this->_encryption_type) {
         case encryption_type::asymmetric:
             return this->encryptor->encrypt(plain, destination);
@@ -172,6 +175,9 @@ void TenSEALContext::encrypt_zero(Ciphertext& destination) const {
 }
 void TenSEALContext::encrypt_zero(parms_id_type parms_id,
                                   Ciphertext& destination) const {
+    if (this->encryptor == nullptr)
+        throw invalid_argument("this context doesn't support encryption");
+
     switch (this->_encryption_type) {
         case encryption_type::asymmetric:
             return this->encryptor->encrypt_zero(parms_id, destination);
@@ -184,9 +190,8 @@ void TenSEALContext::encrypt_zero(parms_id_type parms_id,
 }
 void TenSEALContext::decrypt(const Ciphertext& encrypted,
                              Plaintext& destination) const {
-    if (is_public()) {
-        throw invalid_argument(
-            "the current context is public, it cannot decrypt");
+    if (this->_secret_key == nullptr) {
+        throw invalid_argument("this context doesn't support decryption");
     }
     return this->decrypt(*this->_secret_key, encrypted, destination);
 }


### PR DESCRIPTION
## Description
This PR fixes the following scenario:
 - Serialize a context without the encryption key.
 - Recreate it on the other end and try to create a tensor with it.
 - This should end with an exception, since we cannot encrypt in the current context.
 - Instead, there is a SEGFAULT from the NULL encryption key.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
