### PR TITLE
BatchEncoder single value encoding

### DIFF
--- a/tenseal/cpp/context/tensealencoder.h
+++ b/tenseal/cpp/context/tensealencoder.h
@@ -52,6 +52,16 @@ class TenSEALEncoder {
         auto encoder = this->get<T>();
         encoder->encode(vec, pt);
     }
+    // encode a single int64_t value using BatchEncoder
+    // BatchEncoder doesn't support single value encoding
+    // we have to create a vector of repeated values then encode it
+    template <class T>
+    void encode(int64_t value, Plaintext& pt) {
+        auto encoder = this->get<T>();
+        size_t slot_count = encoder->slot_count();
+        vector<int64_t> vec(slot_count, value);
+        encoder->encode(vec, pt);
+    }
 
     template <class CKKSEncoder>
     void encode(const gsl::span<const double>& vec, Plaintext& pt,


### PR DESCRIPTION
## Description
Add support to encode a single `int64_t` value using BatchEncoder for BFV Vector.
Unlike `CKKSEncoder`, `BatchEncoder` doesn't support encoding single `int64_t`.
This is required in order to implement #246, #247, #248.

## Affected Dependencies
None.

## How has this been tested?
- I have tested it using BFV Vector plain operations.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
