### PR TITLE
Bfvvector add plain

### DIFF
--- a/tenseal/binding.cpp
+++ b/tenseal/binding.cpp
@@ -107,6 +107,8 @@ PYBIND11_MODULE(_tenseal_cpp, m) {
              })
         .def("add", &BFVVector::add)
         .def("add_", &BFVVector::add_inplace)
+        .def("add_plain", py::overload_cast<const int64_t &>(
+                              &BFVVector::add_plain, py::const_))
         .def("add_plain",
              [](shared_ptr<BFVVector> obj, const vector<int64_t> &other) {
                  return obj->add_plain(other);
@@ -115,6 +117,8 @@ PYBIND11_MODULE(_tenseal_cpp, m) {
              [](shared_ptr<BFVVector> obj, const vector<int64_t> &other) {
                  return obj->add_plain_inplace(other);
              })
+        .def("add_plain_",
+             py::overload_cast<const int64_t &>(&BFVVector::add_plain_inplace))
         .def("sub", &BFVVector::sub)
         .def("sub_", &BFVVector::sub_inplace)
         .def("sub_plain",
@@ -137,11 +141,15 @@ PYBIND11_MODULE(_tenseal_cpp, m) {
              })
         // python arithmetic
         .def("__add__", &BFVVector::add)
+        .def("__add__", py::overload_cast<const int64_t &>(
+                            &BFVVector::add_plain, py::const_))
         .def("__add__",
              [](shared_ptr<BFVVector> obj, const vector<int64_t> &other) {
                  return obj->add_plain(other);
              })
         .def("__iadd__", &BFVVector::add_inplace)
+        .def("__iadd__",
+             py::overload_cast<const int64_t &>(&BFVVector::add_plain_inplace))
         .def("__iadd__",
              [](shared_ptr<BFVVector> obj, const vector<int64_t> &other) {
                  return obj->add_plain_inplace(other);

--- a/tenseal/cpp/tensors/bfvvector.h
+++ b/tenseal/cpp/tensors/bfvvector.h
@@ -122,6 +122,12 @@ class BFVVector
     double scale() const override { throw logic_error("not implemented"); }
 
    private:
+    /*
+    Private evaluation functions to process both scalar and vector arguments.
+    */
+    template <typename T>
+    void _add_plain_inplace(Ciphertext& ct, const T& to_add);
+
     BFVVector(const shared_ptr<TenSEALContext>& ctx, const plain_t& vec);
     BFVVector(const shared_ptr<const BFVVector>&);
     BFVVector(const shared_ptr<TenSEALContext>& ctx, const string& vec);

--- a/tests/python/tenseal/tensors/test_bfv_vector.py
+++ b/tests/python/tenseal/tensors/test_bfv_vector.py
@@ -82,6 +82,9 @@ def test_add_inplace(context, vec1, vec2):
         ([1, 2, 3, 4], [4, 3, 2, 1]),
         ([-1, -2], [-73, -10]),
         ([1, 2], [-73, -10]),
+        ([1, 2, 3, 4], 2),
+        ([1, 2, 3, 4], 0),
+        ([1, 2, 3, 4], -2),
         ([2 * i for i in range(10000)], [3 * i for i in range(10000)]),
         ([2 * i for i in range(100000)], [3 * i for i in range(100000)]),
     ],
@@ -92,7 +95,10 @@ def test_add_plain(context, vec1, vec2):
     second_vec = vec2
     result = first_vec + second_vec
 
-    expected = [v1 + v2 for v1, v2 in zip(vec1, vec2)]
+    if isinstance(vec2, list):
+        expected = [v1 + v2 for v1, v2 in zip(vec1, vec2)]
+    elif isinstance(vec2, (float, int)):
+        expected = [v1 + vec2 for v1 in vec1]
 
     # Decryption
     decrypted_result = result.decrypt()
@@ -112,6 +118,40 @@ def test_add_plain(context, vec1, vec2):
         ([1, 2, 3, 4], [4, 3, 2, 1]),
         ([-1, -2], [-73, -10]),
         ([1, 2], [-73, -10]),
+        ([1, 2, 3, 4], 2),
+        ([1, 2, 3, 4], 0),
+        ([1, 2, 3, 4], -2),
+    ],
+)
+def test_radd_plain(context, vec1, vec2):
+    first_vec = ts.bfv_vector(context, vec1)
+    result = vec2 + first_vec
+    if isinstance(vec2, list):
+        expected = [v1 + v2 for v1, v2 in zip(vec1, vec2)]
+    elif isinstance(vec2, (float, int)):
+        expected = [v1 + vec2 for v1 in vec1]
+
+    # Decryption
+    decrypted_result = result.decrypt()
+    assert decrypted_result == expected, "Addition of vectors is incorrect."
+    assert first_vec.decrypt() == vec1, "Something went wrong in memory."
+
+
+@pytest.mark.parametrize(
+    "vec1, vec2",
+    [
+        ([0], [0]),
+        ([1], [0]),
+        ([-1], [0]),
+        ([-1], [-1]),
+        ([1], [1]),
+        ([-1], [1]),
+        ([1, 2, 3, 4], [4, 3, 2, 1]),
+        ([-1, -2], [-73, -10]),
+        ([1, 2], [-73, -10]),
+        ([1, 2, 3, 4], 2),
+        ([1, 2, 3, 4], 0),
+        ([1, 2, 3, 4], -2),
         ([2 * i for i in range(10000)], [3 * i for i in range(10000)]),
         ([2 * i for i in range(100000)], [3 * i for i in range(100000)]),
     ],
@@ -119,10 +159,12 @@ def test_add_plain(context, vec1, vec2):
 def test_add_plain_inplace(context, vec1, vec2):
     first_vec = ts.bfv_vector(context, vec1)
     second_vec = vec2
-
     first_vec += second_vec
 
-    expected = [v1 + v2 for v1, v2 in zip(vec1, vec2)]
+    if isinstance(vec2, list):
+        expected = [v1 + v2 for v1, v2 in zip(vec1, vec2)]
+    elif isinstance(vec2, (float, int)):
+        expected = [v1 + vec2 for v1 in vec1]
 
     # Decryption
     decrypted_result = first_vec.decrypt()


### PR DESCRIPTION
## Description
Implement `add_plain_inplace` operation for `BFVVector`.

Fixes #246.

## Affected Dependencies
None

## How has this been tested?
- C++ tests.
- Python tests.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
