### PR TITLE
Change minimum required CMake version to 3.14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.14)
 
 project(tenseal)
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Supported platforms and their requirements are listed below: (this are only requ
 - **MacOS:** Xcode toolchain (>= 9.3)
 - **Windows:** Microsoft Visual Studio (>= 10.0.40219.1, Visual Studio 2010 SP1 or later).
 
-If you want to install tenseal from the repository, you should first make sure to have the requirements for your platform (listed above) and [CMake (3.12 or higher)](https://cmake.org/install/) installed, then get the third party libraries (if you didn't already) by running the following command from the root directory of the project
+If you want to install tenseal from the repository, you should first make sure to have the requirements for your platform (listed above) and [CMake (3.14 or higher)](https://cmake.org/install/) installed, then get the third party libraries (if you didn't already) by running the following command from the root directory of the project
 
 ```bash
 $ git submodule init


### PR DESCRIPTION
## Description
The minimum required CMake version in the project is 3.13. However, when I build TenSeal from source using CMake 3.13.x I get the following error:

```
CMake Error at cmake/seal.cmake:12 (FetchContent_MakeAvailable):
      Unknown CMake command "FetchContent_MakeAvailable".
    Call Stack (most recent call first):
      CMakeLists.txt:17 (include)
```

The `FetchContent_MakeAvailable` module was introduced in CMake 3.14 (https://cmake.org/cmake/help/v3.14/release/3.14.html#modules). I am able to build and install TenSeal after upgrading CMake to version 3.14.

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?

Updates have been tested by running the C++ and Python tests.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
