### PR TITLE
Feature379 ckksvector shape

### DIFF
--- a/tenseal/tensors/ckksvector.py
+++ b/tenseal/tensors/ckksvector.py
@@ -51,7 +51,7 @@ class CKKSVector(AbstractTensor):
 
     def size(self) -> int:
         return self.data.size()
-    
+
     @property
     def shape(self) -> List[int]:
         return [self.size()]

--- a/tenseal/tensors/ckksvector.py
+++ b/tenseal/tensors/ckksvector.py
@@ -51,6 +51,10 @@ class CKKSVector(AbstractTensor):
 
     def size(self) -> int:
         return self.data.size()
+    
+    @property
+    def shape(self) -> List[int]:
+        return [self.size()]
 
     def ciphertext(self) -> List["ts._ts_cpp.Ciphertext"]:
         return self.data.ciphertext()

--- a/tests/python/tenseal/tensors/test_ckks_vector.py
+++ b/tests/python/tenseal/tensors/test_ckks_vector.py
@@ -1282,3 +1282,9 @@ def test_size(context):
     for size in range(1, 10):
         vec = ts.ckks_vector(context, [1] * size)
         assert vec.size() == size, "Size of encrypted vector is incorrect."
+
+
+def test_shape(context):
+    for size in range(1, 10):
+        vec = ts.ckks_vector(context, [1] * size)
+        assert vec.shape == [size], "Shape of encrypted vector is incorrect."


### PR DESCRIPTION
## Description
As stated in issue #379, it is strange that the property `shape` is defined for `AbstractTensor`, but calling it on a `CKKSVector` raises an error. Therefore, I have overriden the property `shape` for `CKKSVector`, simply calling the method `size`.

## Affected Dependencies
None

## How has this been tested?
- Added a unit test for `shape` almost identical to the one for `size`.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
