### PR TITLE
ignoring zero diagonals in diagonal_ct_vector_matmul

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,16 +57,18 @@ class CMakeBuild(build_ext):
         cfg = "Debug" if self.debug else "Release"
         build_args = ["--config", cfg]
 
+        env = os.environ.copy()
+
         if platform.system() == "Windows":
             cmake_args += [f"-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{cfg.upper()}={extdir}"]
-            if sys.maxsize > 2 ** 32:
+            if sys.maxsize > 2**32:
                 cmake_args += ["-A", "x64"]
             build_args += ["--", "/m", "/p:TrackFileAccess=false"]
         else:
             cmake_args += ["-DCMAKE_BUILD_TYPE=" + cfg]
-            build_args += ["--", "-j"]
+            if "MAKEFLAGS" not in env:
+                build_args += ["--", "-j"]
 
-        env = os.environ.copy()
         env["CXXFLAGS"] = '{} -DVERSION_INFO=\\"{}\\"'.format(
             env.get("CXXFLAGS", ""), self.distribution.get_version()
         )

--- a/tenseal/cpp/tensors/encrypted_vector.h
+++ b/tenseal/cpp/tensors/encrypted_vector.h
@@ -186,28 +186,33 @@ class EncryptedVector : public EncryptedTensor<plain_t, encrypted_t> {
                 auto diag = matrix.get_diagonal(
                     -local_i,
                     this->tenseal_context()->template slot_count<encoder_t>());
-                replicate_vector(
-                    diag,
-                    this->tenseal_context()->template slot_count<encoder_t>());
+                bool is_diag_nonzero = std::any_of(
+                    diag.begin(), diag.end(),
+                    [](plain_t x){return x != 0;});
+                if (is_diag_nonzero) {
+                    replicate_vector(
+                        diag,
+                        this->tenseal_context()->template slot_count<encoder_t>());
 
-                rotate(diag.begin(), diag.begin() + diag.size() - local_i,
-                       diag.end());
+                    rotate(diag.begin(), diag.begin() + diag.size() - local_i,
+                        diag.end());
 
-                this->tenseal_context()->template encode<encoder_t>(diag,
-                                                                    pt_diag);
+                    this->tenseal_context()->template encode<encoder_t>(diag,
+                                                                        pt_diag);
 
-                if (this->_ciphertexts[0].parms_id() != pt_diag.parms_id()) {
-                    this->set_to_same_mod(pt_diag, _ciphertexts[0]);
+                    if (this->_ciphertexts[0].parms_id() != pt_diag.parms_id()) {
+                        this->set_to_same_mod(pt_diag, _ciphertexts[0]);
+                    }
+                    this->tenseal_context()->evaluator->multiply_plain(
+                        this->_ciphertexts[0], pt_diag, ct);
+
+                    this->tenseal_context()->evaluator->rotate_vector_inplace(
+                        ct, local_i, *this->tenseal_context()->galois_keys());
+
+                    // accumulate thread results
+                    this->tenseal_context()->evaluator->add_inplace(thread_result,
+                                                                    ct);
                 }
-                this->tenseal_context()->evaluator->multiply_plain(
-                    this->_ciphertexts[0], pt_diag, ct);
-
-                this->tenseal_context()->evaluator->rotate_vector_inplace(
-                    ct, local_i, *this->tenseal_context()->galois_keys());
-
-                // accumulate thread results
-                this->tenseal_context()->evaluator->add_inplace(thread_result,
-                                                                ct);
             }
             return thread_result;
         };

--- a/tenseal/cpp/tensors/encrypted_vector.h
+++ b/tenseal/cpp/tensors/encrypted_vector.h
@@ -186,7 +186,7 @@ class EncryptedVector : public EncryptedTensor<plain_t, encrypted_t> {
                 auto diag = matrix.get_diagonal(
                     -local_i,
                     this->tenseal_context()->template slot_count<encoder_t>());
-                
+
                 // don't add zero diagonals to (a) improve performance and (b)
                 // avoid transparent ciphertext issues
                 bool is_diag_nonzero = std::any_of(

--- a/tenseal/cpp/tensors/encrypted_vector.h
+++ b/tenseal/cpp/tensors/encrypted_vector.h
@@ -186,6 +186,9 @@ class EncryptedVector : public EncryptedTensor<plain_t, encrypted_t> {
                 auto diag = matrix.get_diagonal(
                     -local_i,
                     this->tenseal_context()->template slot_count<encoder_t>());
+                
+                // don't add zero diagonals to (a) improve performance and (b)
+                // avoid transparent ciphertext issues
                 bool is_diag_nonzero = std::any_of(
                     diag.begin(), diag.end(), [](plain_t x) { return x != 0; });
                 if (is_diag_nonzero) {

--- a/tenseal/cpp/tensors/encrypted_vector.h
+++ b/tenseal/cpp/tensors/encrypted_vector.h
@@ -187,20 +187,20 @@ class EncryptedVector : public EncryptedTensor<plain_t, encrypted_t> {
                     -local_i,
                     this->tenseal_context()->template slot_count<encoder_t>());
                 bool is_diag_nonzero = std::any_of(
-                    diag.begin(), diag.end(),
-                    [](plain_t x){return x != 0;});
+                    diag.begin(), diag.end(), [](plain_t x) { return x != 0; });
                 if (is_diag_nonzero) {
-                    replicate_vector(
-                        diag,
-                        this->tenseal_context()->template slot_count<encoder_t>());
+                    replicate_vector(diag,
+                                     this->tenseal_context()
+                                         ->template slot_count<encoder_t>());
 
                     rotate(diag.begin(), diag.begin() + diag.size() - local_i,
-                        diag.end());
+                           diag.end());
 
-                    this->tenseal_context()->template encode<encoder_t>(diag,
-                                                                        pt_diag);
+                    this->tenseal_context()->template encode<encoder_t>(
+                        diag, pt_diag);
 
-                    if (this->_ciphertexts[0].parms_id() != pt_diag.parms_id()) {
+                    if (this->_ciphertexts[0].parms_id() !=
+                        pt_diag.parms_id()) {
                         this->set_to_same_mod(pt_diag, _ciphertexts[0]);
                     }
                     this->tenseal_context()->evaluator->multiply_plain(
@@ -210,8 +210,8 @@ class EncryptedVector : public EncryptedTensor<plain_t, encrypted_t> {
                         ct, local_i, *this->tenseal_context()->galois_keys());
 
                     // accumulate thread results
-                    this->tenseal_context()->evaluator->add_inplace(thread_result,
-                                                                    ct);
+                    this->tenseal_context()->evaluator->add_inplace(
+                        thread_result, ct);
                 }
             }
             return thread_result;

--- a/tests/python/tenseal/tensors/test_ckks_tensor.py
+++ b/tests/python/tenseal/tensors/test_ckks_tensor.py
@@ -121,19 +121,39 @@ def test_reshape_batching(context, data, new_shape):
 @pytest.mark.parametrize(
     "data, slices, new_shape",
     [
-        ([0, 1, 2, 3, 4, 5], [slice(1, 4, None)], [3]),
-        ([0, 1, 2, 3, 4, 5], [slice(1, None, None)], [5]),
-        ([0, 1, 2, 3, 4, 5], [slice(None, 4, None)], [4]),
-        ([[0, 1, 2], [0, 1, 2], [0, 1, 2]], [slice(1, 3, None), slice(0, 2, None)], [2, 2]),
-        ([[0, 1, 2], [0, 1, 2], [0, 1, 2]], [slice(1, None, None), slice(0, 2, None)], [2, 2]),
+        ([0, 1, 2, 3, 4, 5], (slice(1, 4, None),), [3]),
+        ([0, 1, 2, 3, 4, 5], (slice(1, None, None),), [5]),
+        ([0, 1, 2, 3, 4, 5], (slice(None, 4, None),), [4]),
         (
             [[0, 1, 2], [0, 1, 2], [0, 1, 2]],
-            [slice(1, None, None), slice(None, None, None)],
+            (
+                slice(1, 3, None),
+                slice(0, 2, None),
+            ),
+            [2, 2],
+        ),
+        (
+            [[0, 1, 2], [0, 1, 2], [0, 1, 2]],
+            (
+                slice(1, None, None),
+                slice(0, 2, None),
+            ),
+            [2, 2],
+        ),
+        (
+            [[0, 1, 2], [0, 1, 2], [0, 1, 2]],
+            (
+                slice(1, None, None),
+                slice(None, None, None),
+            ),
             [2, 3],
         ),
         (
             [[0, 1, 2], [0, 1, 2], [0, 1, 2]],
-            [slice(None, None, None), slice(None, None, None)],
+            (
+                slice(None, None, None),
+                slice(None, None, None),
+            ),
             [3, 3],
         ),
         ([[0, 1, 2], [0, 1, 2], [0, 1, 2]], 1, [1, 3]),


### PR DESCRIPTION
## Description
As explained in #398, matrices with diagonals that contain nothing but zeros cannot be multiplied with a vector, as this results in `ValueError: result ciphertext is transparent`. This can be fixed by simply ignoring zero diagonals, which in addition potentially saves some unnecessary computations.

## Affected Dependencies
None

## How has this been tested?
I used the following code to test, which previously resulted in the error explained above.
```python
import numpy as np
import tenseal as ts

n = 1000
x = np.random.rand(n)
i = np.eye(n)
poly_mod_degree = 4096
coeff_mod_bit_sizes = [40, 20, 40]
ctx = ts.context(ts.SCHEME_TYPE.CKKS, poly_mod_degree, -1, coeff_mod_bit_sizes)
ctx.generate_galois_keys()
ctx.global_scale = 2 ** 20
x_enc = ts.ckks_vector(ctx, x)
x_enc @ i
```

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
