### PR TITLE
fix: don't call batch() if batch == False

### DIFF
--- a/tenseal/cpp/tensors/ckkstensor.cpp
+++ b/tenseal/cpp/tensors/ckkstensor.cpp
@@ -17,9 +17,10 @@ CKKSTensor::CKKSTensor(const shared_ptr<TenSEALContext>& ctx,
 
     vector<Ciphertext> enc_data;
     vector<size_t> enc_shape = tensor.shape();
-    auto data = tensor.batch(0);
+    decltype(tensor.batch(0)) data;
     size_t size;
     if (batch) {
+        data = tensor.batch(0);
         _batch_size = enc_shape[0];
         enc_shape.erase(enc_shape.begin());
         size = tensor.batch(0).size();


### PR DESCRIPTION
## Description
Currently, creating a CKKSTensor from a PyTorch scalar throws an exception even with `batch=False`.

```python3
import torch
import tenseal as ts

ctx = ts.context(
    ts.SCHEME_TYPE.CKKS, 8192, coeff_mod_bit_sizes=[60, 40, 40, 60]
)
ctx.global_scale = 2**10

ts.CKKSTensor(ctx, torch.tensor(3), batch=False)

```

```
Traceback (most recent call last):
  File "a.py", line 9, in <module>
    ts.CKKSTensor(ctx, torch.tensor(3), batch=False)
  File "...python3.10/site-packages/tenseal/tensors/ckkstensor.py", line 44, in __init__
    self.data = ts._ts_cpp.CKKSTensor(context.data, tensor.data, batch)
ValueError: invalid dimension for batching
```

This pr fixes it by not calling `TensorStorage::batch` if `batch==false`.

## Affected Dependencies
None.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
