### PR TITLE
[New Feature]: Add support for transposing a tensor along a specified axes

### DIFF
--- a/tenseal/binding.cpp
+++ b/tenseal/binding.cpp
@@ -143,8 +143,12 @@ void bind_plain_tensor(py::module &m, const std::string &name) {
         .def("replicate", &type::replicate)
         .def("broadcast", &type::broadcast)
         .def("broadcast_", &type::broadcast_inplace)
-        .def("transpose", &type::transpose)
-        .def("transpose_", &type::transpose_inplace)
+        .def("transpose", py::overload_cast<>(&type::transpose, py::const_))
+        .def("transpose_", py::overload_cast<>(&type::transpose_inplace))
+        .def("transpose", py::overload_cast<const std::vector<size_t> &>(
+                                   &type::transpose, py::const_))
+        .def("transpose_", py::overload_cast<const std::vector<size_t> &>(
+                                   &type::transpose_inplace))
         .def("serialize", [](type &obj) { return py::bytes(obj.save()); });
 }
 
@@ -709,8 +713,12 @@ void bind_ckks_tensor(py::module &m) {
         .def("reshape_", &CKKSTensor::reshape_inplace)
         .def("broadcast", &CKKSTensor::broadcast)
         .def("broadcast_", &CKKSTensor::broadcast_inplace)
-        .def("transpose", &CKKSTensor::transpose)
-        .def("transpose_", &CKKSTensor::transpose_inplace)
+        .def("transpose", py::overload_cast<>(&CKKSTensor::transpose, py::const_))
+        .def("transpose_", py::overload_cast<>(&CKKSTensor::transpose_inplace))
+        .def("transpose", py::overload_cast<const std::vector<size_t> &>(
+                              &CKKSTensor::transpose, py::const_))
+        .def("transpose_", py::overload_cast<const std::vector<size_t> &>(
+                               &CKKSTensor::transpose_inplace))
         .def("scale", &CKKSTensor::scale);
 }
 

--- a/tenseal/cpp/tensors/ckkstensor.cpp
+++ b/tenseal/cpp/tensors/ckkstensor.cpp
@@ -764,6 +764,14 @@ shared_ptr<CKKSTensor> CKKSTensor::transpose_inplace() {
 
     return shared_from_this();
 }
+shared_ptr<CKKSTensor> CKKSTensor::transpose(const vector<size_t>& permutation) const {
+    return this->copy()->transpose_inplace(permutation);
+}
+shared_ptr<CKKSTensor> CKKSTensor::transpose_inplace(const vector<size_t>& permutation) {
+    this->_data.transpose_inplace(permutation);
+
+    return shared_from_this();
+}
 
 double CKKSTensor::scale() const { return _init_scale; }
 }  // namespace tenseal

--- a/tenseal/cpp/tensors/ckkstensor.h
+++ b/tenseal/cpp/tensors/ckkstensor.h
@@ -114,6 +114,8 @@ class CKKSTensor : public EncryptedTensor<double, shared_ptr<CKKSTensor>>,
 
     shared_ptr<CKKSTensor> transpose() const;
     shared_ptr<CKKSTensor> transpose_inplace();
+    shared_ptr<CKKSTensor> transpose(const vector<size_t>& permutation) const;
+    shared_ptr<CKKSTensor> transpose_inplace(const vector<size_t>& permutation);
 
     vector<size_t> shape_with_batch() const;
     double scale() const override;

--- a/tenseal/cpp/tensors/plain_tensor.h
+++ b/tenseal/cpp/tensors/plain_tensor.h
@@ -85,6 +85,13 @@ class PlainTensor {
         this->_data.transpose_inplace();
         return *this;
     }
+    PlainTensor<plain_t> transpose(const vector<size_t>& permutation) const {
+        return this->copy().transpose_inplace(permutation);
+    }
+    PlainTensor<plain_t>& transpose_inplace(const vector<size_t>& permutation) {
+        this->_data.transpose_inplace(permutation);
+        return *this;
+    }
     /**
      * Returns the element at position {idx1, idx2, ..., idxn} in the current
      * shape

--- a/tenseal/cpp/tensors/tensor_storage.h
+++ b/tenseal/cpp/tensors/tensor_storage.h
@@ -162,6 +162,16 @@ class TensorStorage {
         this->_data = xt::transpose(this->_data);
         return *this;
     }
+
+    TensorStorage<dtype_t> transpose(const vector<size_t>& axes) const {
+        return this->copy().transpose_inplace(axes);
+    }
+
+    TensorStorage<dtype_t> transpose_inplace(const vector<size_t>& axes) {
+        this->_data = xt::transpose(this->_data, axes);
+        return *this;
+    }
+
     /**
      * Returns the element at position {idx1, idx2, ..., idxn} in the current
      * shape

--- a/tenseal/tensors/ckkstensor.py
+++ b/tenseal/tensors/ckkstensor.py
@@ -156,12 +156,23 @@ class CKKSTensor(AbstractTensor):
         self.data.broadcast_(shape)
         return self
 
-    def transpose(self):
+    def transpose(self, axes: List[int] = None) -> "CKKSTensor":
         "Copies the transpose to a new tensor"
-        result = self.data.transpose()
+        result = None
+        if axes is None:
+            result = self.data.transpose()
+        elif isinstance(axes, list) and all(isinstance(x, int) for x in axes):
+            result = self.data.transpose(axes)
+        else:
+            raise TypeError("axes must be a list of integers")
         return self._wrap(result)
 
-    def transpose_(self):
+    def transpose_(self, axes: List[int] = None) -> "CKKSTensor":
         "Tries to transpose the tensor"
-        self.data.transpose_()
+        if axes is None:
+            self.data.transpose_()
+        elif isinstance(axes, list) and all(isinstance(x, int) for x in axes):
+            self.data.transpose_(axes)
+        else:
+            raise TypeError("axes must be a list of integers")
         return self

--- a/tenseal/tensors/plaintensor.py
+++ b/tenseal/tensors/plaintensor.py
@@ -126,14 +126,23 @@ class PlainTensor:
         self.data.broadcast_(shape)
         return self
 
-    def transpose(self):
+    def transpose(self, axes: List[int] = None):
         "Copies the transpose to a new tensor"
-        new_tensor = PlainTensor(tensor=self.data.data(), shape=self.shape, dtype=self._dtype)
+        new_tensor = None
+        if axes is None:
+            new_tensor = PlainTensor(tensor=self.data.data(), shape=self.shape, dtype=self._dtype)
+        elif isinstance(axes, list) and all(isinstance(x, int) for x in axes):
+            new_tensor = PlainTensor(tensor=self.data.data(), shape=self.shape, dtype=self._dtype)
+        else:
+            raise TypeError("axes must be a list of integers")
         return new_tensor.transpose_()
 
-    def transpose_(self):
+    def transpose_(self, axes: List[int] = None):
         "Tries to transpose the tensor"
-        self.data.transpose_()
+        if axes is None:
+            self.data.transpose_()
+        elif isinstance(axes, list) and all(isinstance(x, int) for x in axes):
+            self.data.transpose_(axes)
         return self
 
     @classmethod

--- a/tenseal/tensors/plaintensor.py
+++ b/tenseal/tensors/plaintensor.py
@@ -128,14 +128,13 @@ class PlainTensor:
 
     def transpose(self, axes: List[int] = None):
         "Copies the transpose to a new tensor"
-        new_tensor = None
+        new_tensor = PlainTensor(tensor=self.data.data(), shape=self.shape, dtype=self._dtype)
         if axes is None:
-            new_tensor = PlainTensor(tensor=self.data.data(), shape=self.shape, dtype=self._dtype)
+            return new_tensor.transpose_()
         elif isinstance(axes, list) and all(isinstance(x, int) for x in axes):
-            new_tensor = PlainTensor(tensor=self.data.data(), shape=self.shape, dtype=self._dtype)
+            return new_tensor.transpose_(axes)
         else:
-            raise TypeError("axes must be a list of integers")
-        return new_tensor.transpose_()
+            raise TypeError("transpose axes must be a list of integers")
 
     def transpose_(self, axes: List[int] = None):
         "Tries to transpose the tensor"
@@ -143,6 +142,8 @@ class PlainTensor:
             self.data.transpose_()
         elif isinstance(axes, list) and all(isinstance(x, int) for x in axes):
             self.data.transpose_(axes)
+        else:
+            raise TypeError("transpose axes must be a list of integers")
         return self
 
     @classmethod

--- a/tests/python/tenseal/tensors/test_ckks_tensor.py
+++ b/tests/python/tenseal/tensors/test_ckks_tensor.py
@@ -826,3 +826,27 @@ def test_transpose(context, data, shape):
     assert tensor.shape == list(expected.shape)
     result = np.array(tensor.decrypt().tolist())
     assert np.allclose(result, expected, rtol=0, atol=0.01)
+
+@pytest.mark.parametrize(
+    "data, shape, axes",
+    [
+        ([i for i in range(6)], [1, 2, 3], [0, 2, 1]),
+        ([i for i in range(12)], [2, 2, 3], [0, 2, 1]),
+        ([i for i in range(2 * 3 * 4 * 5)], [2, 3, 4, 5], [0, 3, 2, 1]),
+    ],
+)
+def test_transpose_with_axes(context, data, shape, axes):
+    tensor = ts.ckks_tensor(context, ts.plain_tensor(data, shape))
+
+    expected = np.transpose(np.array(data).reshape(shape), axes)
+
+    newt = tensor.transpose(axes)
+    assert tensor.shape == shape
+    assert newt.shape == list(expected.shape)
+    result = np.array(newt.decrypt().tolist())
+    assert np.allclose(result, expected, rtol=0, atol=0.01)
+
+    tensor.transpose_(axes)
+    assert tensor.shape == list(expected.shape)
+    result = np.array(tensor.decrypt().tolist())
+    assert np.allclose(result, expected, rtol=0, atol=0.01)

--- a/tests/python/tenseal/tensors/test_plain_tensor.py
+++ b/tests/python/tenseal/tensors/test_plain_tensor.py
@@ -128,3 +128,25 @@ def test_transpose(data, shape):
     tensor.transpose_()
     assert tensor.shape == list(expected.shape)
     assert np.array(tensor.tolist()).any() == expected.any()
+
+@pytest.mark.parametrize(
+    "data, shape, axes",
+    [
+        ([i for i in range(6)], [1, 2, 3], [0, 2, 1]),
+        ([i for i in range(12)], [2, 2, 3], [0, 2, 1]),
+        ([i for i in range(2 * 3 * 4 * 5)], [2, 3, 4, 5], [0, 3, 2, 1]),
+    ],
+)
+def test_transpose(data, shape, axes):
+    tensor = ts.plain_tensor(data, shape)
+
+    expected = np.transpose(np.array(data).reshape(shape), axes)
+
+    newt = tensor.transpose(axes)
+    assert tensor.shape == shape
+    assert newt.shape == list(expected.shape)
+    assert np.array(newt.tolist()).any() == expected.any()
+
+    tensor.transpose_(axes)
+    assert tensor.shape == list(expected.shape)
+    assert np.array(tensor.tolist()).any() == expected.any()


### PR DESCRIPTION
## Description
Hello, while using TenSEAL, I noticed that the current version does not support transposing a tensor along a specified dimension. This may make it more complicated for users to implement functions like multi-head attention. Based on xtensor, I have modified the existing code to add support for the aforementioned operation in TenSEAL. In this code submission, users can utilize the Python method transpose(0, 2, 1). This operation is consistent with NumPy and can be adapted with minimal changes to support operations similar to PyTorch's transpose(-2, -1).

## Affected Dependencies
No

## How has this been tested?
The test code is included in this pull request.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
