### PR TITLE
Change release workflows trigger to published instead of created

### DIFF
--- a/.github/workflows/pythonpublish-linux.yml
+++ b/.github/workflows/pythonpublish-linux.yml
@@ -2,7 +2,7 @@ name: Linux Package
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   deploy:

--- a/.github/workflows/pythonpublish-macos.yml
+++ b/.github/workflows/pythonpublish-macos.yml
@@ -2,7 +2,7 @@ name: MacOS Package
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   deploy:

--- a/.github/workflows/pythonpublish-windows.yml
+++ b/.github/workflows/pythonpublish-windows.yml
@@ -2,7 +2,7 @@ name: Windows Package
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   deploy:


### PR DESCRIPTION
## Description
Change release workflows trigger to `published` instead of `created` to make sure to trigger publish workflows whenever a release is created.

- Reason: Workflows are not triggered for the created, edited, or deleted activity types for draft releases. When you create your release through the GitHub browser UI, your release may automatically be saved as a draft.
- Source: https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#release

## Affected Dependencies
None

## How has this been tested?
- No need for testing since we are making changes to the GitHub Actions workflows.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
