### PR TITLE
Update CI/CD Workflows

### DIFF
--- a/.github/workflows/bazel_tests.yml
+++ b/.github/workflows/bazel_tests.yml
@@ -15,11 +15,11 @@ jobs:
         python-version: ['3.9']
         os: [macos-latest, ubuntu-latest]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:
           submodules: true
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3
+        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Run gtest

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -12,9 +12,9 @@ jobs:
         os: [macos-latest, ubuntu-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3
+        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Prepare ENV
@@ -32,7 +32,7 @@ jobs:
         run: .github/workflows/scripts/install_req_windows.bat
         if: ${{ matrix.os == 'windows-latest' }}
       - name: Install dependencies Windows - msbuild
-        uses: microsoft/setup-msbuild@v1.0.2
+        uses: microsoft/setup-msbuild@6fb02220983dee41ce7ae257b6f4d8f9bf5ed4ce # v2
         if: ${{ matrix.os == 'windows-latest' }}
       - name: Build the library for Ubuntu/MacOS
         run: .github/workflows/scripts/build_nix.sh
@@ -44,7 +44,7 @@ jobs:
         run: |
           pytest tests/python/benchmarks/ --cov-fail-under 0 --benchmark-json pytest_benchmarks_output.json
       - name: Store benchmark result
-        uses: rhysd/github-action-benchmark@v1
+        uses: benchmark-action/github-action-benchmark@4de1bed97a47495fc4c5404952da0499e31f5c29 # v1.20.3
         with:
           name: Python-Benchmarks
           tool: "pytest"

--- a/.github/workflows/ossar-analysis.yml
+++ b/.github/workflows/ossar-analysis.yml
@@ -15,15 +15,15 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
 
       # Run open source static analysis tools
     - name: Run OSSAR
-      uses: github/ossar-action@v1
+      uses: github/ossar-action@4e96c4f6e591eb4b991abfd459e40b136a317aea # v2.0.0
       id: ossar
 
       # Upload results to the Security tab
     - name: Upload OSSAR results
-      uses: github/codeql-action/upload-sarif@v1
+      uses: github/codeql-action/upload-sarif@5618c9fc1e675841ca52c1c6b1304f5255a905a0 # v2.19.0
       with:
         sarif_file: ${{ steps.ossar.outputs.sarifFile }}

--- a/.github/workflows/pythonpublish-linux.yml
+++ b/.github/workflows/pythonpublish-linux.yml
@@ -20,7 +20,7 @@ jobs:
     container: quay.io/pypa/manylinux2014_x86_64
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:
           submodules: true
       - name: Prepare ENV

--- a/.github/workflows/pythonpublish-linux.yml
+++ b/.github/workflows/pythonpublish-linux.yml
@@ -18,6 +18,12 @@ jobs:
 
     runs-on: ubuntu-latest
     container: quay.io/pypa/manylinux2014_x86_64
+    
+    # node20 can't run on manylinux2014 as it requires newer version of GLIBC
+    # https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
+    env:
+      ACTIONS_RUNNER_FORCE_ACTIONS_NODE_VERSION: node16
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0

--- a/.github/workflows/pythonpublish-linux.yml
+++ b/.github/workflows/pythonpublish-linux.yml
@@ -1,6 +1,7 @@
 name: Linux Package
 
 on:
+  workflow_dispatch:
   release:
     types: [published]
 

--- a/.github/workflows/pythonpublish-macos.yml
+++ b/.github/workflows/pythonpublish-macos.yml
@@ -1,6 +1,7 @@
 name: MacOS Package
 
 on:
+  workflow_dispatch:
   release:
     types: [published]
 

--- a/.github/workflows/pythonpublish-macos.yml
+++ b/.github/workflows/pythonpublish-macos.yml
@@ -14,11 +14,11 @@ jobs:
         os: [macos-12, macos-13, macos-14]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:
           submodules: true
       - name: Set up Python
-        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3
+        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/pythonpublish-macos.yml
+++ b/.github/workflows/pythonpublish-macos.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
-        os: [macos-11, macos-12]
+        os: [macos-12, macos-13, macos-14]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pythonpublish-windows.yml
+++ b/.github/workflows/pythonpublish-windows.yml
@@ -13,17 +13,17 @@ jobs:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:
           submodules: true
       - name: Set up Python
-        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3
+        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: .github/workflows/scripts/install_req_windows.bat
       - name: Setup msbuild
-        uses: microsoft/setup-msbuild@v1.0.2
+        uses: microsoft/setup-msbuild@6fb02220983dee41ce7ae257b6f4d8f9bf5ed4ce # v2
       - name: Build and publish
         env:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}

--- a/.github/workflows/pythonpublish-windows.yml
+++ b/.github/workflows/pythonpublish-windows.yml
@@ -1,6 +1,7 @@
 name: Windows Package
 
 on:
+  workflow_dispatch:
   release:
     types: [published]
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,11 +14,11 @@ jobs:
         python-version: ['3.8', '3.12']
         os: [ubuntu-latest]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:
           submodules: true
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3
+        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -37,11 +37,11 @@ jobs:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         os: [macos-latest, ubuntu-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:
           submodules: true
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3
+        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Check LongPathsEnabled
@@ -64,7 +64,7 @@ jobs:
         run: .github/workflows/scripts/install_req_windows.bat
         if: ${{ matrix.os == 'windows-latest' }}
       - name: Install dependencies Windows - msbuild
-        uses: microsoft/setup-msbuild@v1.0.3
+        uses: microsoft/setup-msbuild@6fb02220983dee41ce7ae257b6f4d8f9bf5ed4ce # v2
         if: ${{ matrix.os == 'windows-latest' }}
       - name: Build the library for Ubuntu/MacOS
         run: .github/workflows/scripts/build_nix.sh
@@ -89,11 +89,11 @@ jobs:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         os: [macos-latest, ubuntu-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:
           submodules: true
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3
+        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Prepare ENV
@@ -116,7 +116,7 @@ jobs:
         run: .github/workflows/scripts/install_req_windows.bat
         if: ${{ matrix.os == 'windows-latest' }}
       - name: Install dependencies Windows - msbuild
-        uses: microsoft/setup-msbuild@v1.0.3
+        uses: microsoft/setup-msbuild@6fb02220983dee41ce7ae257b6f4d8f9bf5ed4ce # v2
         if: ${{ matrix.os == 'windows-latest' }}
       - name: Build the library for Ubuntu/MacOS
         run: .github/workflows/scripts/build_nix.sh


### PR DESCRIPTION
## Description
- Add workflow dispatch for release workflows.
- Update macOS target for release workflows.
- Update all used Actions in the workflows to the latest version and pin them with hash.
- Force using `node16`  ([details](https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/ )) for Linux release publish workflow because `node20` can't run on [manylinux2014](https://github.com/pypa/manylinux) as it requires a newer version of GLIBC.

## Affected Dependencies
- N/A

## How has this been tested?
- GitHub Actions

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
