### PR TITLE
Use Twine to publish wheels

### DIFF
--- a/.github/workflows/publish_wheels.yml
+++ b/.github/workflows/publish_wheels.yml
@@ -46,9 +46,16 @@ jobs:
           name: TenSEAL-${{ matrix.python }}-${{ matrix.target[0] }}
           path: ./wheelhouse/*.whl
 
-      - name: Publish wheels to PyPI
-        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
+      - name: Set up Python
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
-          packages-dir: ./wheelhouse/
-          user: ${{ secrets.PYPI_USERNAME }}
-          password: ${{ secrets.PYPI_PASSWORD }}
+          python-version: "3.13"
+
+      - name: Install twine
+        run: python -m pip install --upgrade twine
+
+      - name: Publish wheels to PyPI
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: twine upload --repository testpypi --skip-existing --verbose wheelhouse/*.whl

--- a/.github/workflows/publish_wheels.yml
+++ b/.github/workflows/publish_wheels.yml
@@ -58,4 +58,4 @@ jobs:
         env:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-        run: twine upload --repository testpypi --skip-existing --verbose wheelhouse/*.whl
+        run: twine upload --repository pypi --skip-existing --verbose wheelhouse/*.whl

--- a/.github/workflows/publish_wheels.yml
+++ b/.github/workflows/publish_wheels.yml
@@ -10,10 +10,10 @@ jobs:
       fail-fast: false
       matrix:
         target:
-          - [ubuntu-latest, manylinux_x86_64]
-          - [windows-latest, win_amd64]
-          - [macos-13, macosx_x86_64]
-          - [macos-14, macosx_arm64]
+          - [ubuntu-latest, manylinux_x86_64, ""]
+          - [windows-latest, win_amd64, ""]
+          - [macos-13, macosx_x86_64, "13.0"]
+          - [macos-14, macosx_arm64, "14.0"]
         python:
           - cp39
           - cp310
@@ -34,6 +34,7 @@ jobs:
         uses: pypa/cibuildwheel@ee63bf16da6cddfb925f542f2c7b59ad50e93969 # v2.22.0
         env:
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
+          MACOSX_DEPLOYMENT_TARGET: ${{ matrix.target[2] }}
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.target[1] }}
           CIBW_BUILD_VERBOSITY: 1
         with:


### PR DESCRIPTION
## Description
Fix publish_wheels workflow by using twine to publish wheels instead of gh-action-pypi-publish Action.
The current workflow was failing because gh-action-pypi-publish Action works on Linux runners only ([details](https://github.com/pypa/gh-action-pypi-publish?tab=readme-ov-file#non-goals)).

## Affected Dependencies
None

## How has this been tested?
I have tested the new workflow in a fork repository, the results can be found [here](https://github.com/philomath213/TenSEAL/actions/runs/13581593494).

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
