### PR TITLE
Publish an sdist and stop partial releases on PyPI

### DIFF
--- a/.github/workflows/publish_wheels.yml
+++ b/.github/workflows/publish_wheels.yml
@@ -1,10 +1,24 @@
 name: Build and Publish
 
 on:
+  release:
+    types: [published]
   workflow_dispatch:
+    inputs:
+      repository:
+        description: "Index to publish to"
+        type: choice
+        options: [testpypi, pypi]
+        default: testpypi
+
+# Nothing here needs to write to the repository; the only credentials used are
+# the index tokens passed explicitly to twine.
+permissions:
+  contents: read
 
 jobs:
-  publish:
+  build_wheels:
+    name: Wheel ${{ matrix.python }}-${{ matrix.target[1] }}
     runs-on: ${{ matrix.target[0] }}
     strategy:
       fail-fast: false
@@ -40,6 +54,11 @@ jobs:
         run: sudo xcode-select -s /Applications/Xcode_15.4.app
         if: ${{ startsWith(matrix.target[0], 'macos') }}
 
+      - name: Stamp a dev version for the TestPyPI rehearsal
+        if: ${{ inputs.repository == 'testpypi' }}
+        shell: bash
+        run: .github/workflows/scripts/stamp_dev_version.sh
+
       - name: Build wheels using cibuildwheel
         uses: pypa/cibuildwheel@298ed2fb2c105540f5ed055e8a6ad78d82dd3a7e # v3.3.1
         env:
@@ -55,11 +74,102 @@ jobs:
           package-dir: .
           output-dir: wheelhouse
 
-      - name: Upload Artifacts
+      - name: Upload wheel artifact
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
-          name: TenSEAL-${{ matrix.python }}-${{ matrix.target[0] }}
+          name: dist-wheel-${{ matrix.python }}-${{ matrix.target[0] }}
           path: ./wheelhouse/*.whl
+
+  build_sdist:
+    name: sdist
+    runs-on: ubuntu-24.04
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          submodules: true
+
+      - name: Set up Python
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
+        with:
+          python-version: "3.13"
+
+      - name: Stamp a dev version for the TestPyPI rehearsal
+        if: ${{ inputs.repository == 'testpypi' }}
+        run: .github/workflows/scripts/stamp_dev_version.sh
+
+      # Read the version *after* stamping so downstream jobs pin the exact
+      # release that was published.
+      - name: Expose the version being published
+        id: version
+        run: |
+          V=$(python -c "import pathlib, re; print(re.search(r'__version__ = \"([^\"]+)\"', pathlib.Path('tenseal/version.py').read_text()).group(1))")
+          echo "version=$V" >> "$GITHUB_OUTPUT"
+          echo "Publishing version $V"
+
+      - name: Build sdist
+        run: pipx run build --sdist
+
+      - name: Check metadata
+        run: pipx run twine check dist/*
+
+      - name: Upload sdist artifact
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: dist-sdist
+          path: ./dist/*.tar.gz
+
+  # Builds a wheel from the *sdist* rather than the git checkout. This is the
+  # only check that catches an incomplete MANIFEST.in - an sdist that unpacks
+  # cleanly but is missing CMakeLists.txt, cmake/ or the .proto files would
+  # still pass `twine check` and then fail for every user who builds from
+  # source.
+  test_sdist:
+    name: Build a wheel from the sdist
+    needs: [build_sdist]
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Download sdist
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: dist-sdist
+          path: dist
+
+      - name: Unpack the sdist
+        run: |
+          mkdir -p sdist-src
+          tar xzf dist/*.tar.gz -C sdist-src --strip-components=1
+          echo "Contents that CMake needs:"
+          ls sdist-src/CMakeLists.txt sdist-src/cmake/ sdist-src/tenseal/proto/*.proto
+
+      - name: Build and import-test the wheel from the sdist
+        uses: pypa/cibuildwheel@298ed2fb2c105540f5ed055e8a6ad78d82dd3a7e # v3.3.1
+        env:
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
+          CIBW_BUILD: cp313-manylinux_x86_64
+          CIBW_BUILD_VERBOSITY: 1
+          CIBW_ENVIRONMENT: "CMAKE_POLICY_VERSION_MINIMUM=3.5"
+          CIBW_TEST_COMMAND: 'python -c "import tenseal; print(tenseal.__version__)"'
+        with:
+          package-dir: sdist-src
+          output-dir: sdist-wheelhouse
+
+  # One upload for the whole release. Previously each of the 12 matrix cells
+  # published on its own, so a failure partway through left a half-published
+  # release on the index.
+  publish:
+    name: Publish to ${{ github.event_name == 'release' && 'pypi' || inputs.repository }}
+    needs: [build_wheels, build_sdist, test_sdist]
+    runs-on: ubuntu-24.04
+    environment: ${{ github.event_name == 'release' && 'pypi' || inputs.repository }}
+    steps:
+      - name: Download all distributions
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          pattern: dist-*
+          merge-multiple: true
+          path: dist
 
       - name: Set up Python
         uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
@@ -69,8 +179,62 @@ jobs:
       - name: Install twine
         run: python -m pip install --upgrade twine
 
-      - name: Publish wheels to PyPI
+      - name: List and verify what will be uploaded
+        run: |
+          ls -lh dist/
+          twine check dist/*
+
+      - name: Publish to TestPyPI
+        if: ${{ inputs.repository == 'testpypi' }}
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        run: twine upload --repository testpypi --skip-existing --verbose dist/*
+
+      - name: Publish to PyPI
+        if: ${{ github.event_name == 'release' || inputs.repository == 'pypi' }}
         env:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-        run: twine upload --repository pypi --skip-existing --verbose wheelhouse/*.whl
+        run: twine upload --repository pypi --skip-existing --verbose dist/*
+
+  # The half of a TestPyPI rehearsal that actually pays off: prove the published
+  # artifacts resolve, select the right wheel per platform, and import.
+  verify_install:
+    name: Install from TestPyPI (${{ matrix.os }})
+    needs: [build_sdist, publish]
+    if: ${{ inputs.repository == 'testpypi' }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, windows-2022, macos-14]
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
+        with:
+          python-version: "3.13"
+
+      # --extra-index-url is mandatory: TestPyPI does not carry numpy, which is
+      # a declared runtime dependency, so the install would fail for reasons
+      # unrelated to the package under test.
+      - name: Install from TestPyPI
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install \
+            --index-url https://test.pypi.org/simple/ \
+            --extra-index-url https://pypi.org/simple/ \
+            "tenseal==${{ needs.build_sdist.outputs.version }}"
+
+      - name: Smoke test the installed wheel
+        shell: bash
+        run: |
+          python -c "
+          import tenseal as ts
+          ctx = ts.context(ts.SCHEME_TYPE.CKKS, 8192, coeff_mod_bit_sizes=[60, 40, 40, 60])
+          ctx.global_scale = 2**40
+          v = ts.ckks_vector(ctx, [1.0, 2.0, 3.0])
+          assert [round(x) for x in (v + v).decrypt()] == [2, 4, 6]
+          print('tenseal', ts.__version__, 'installed from TestPyPI and working')
+          "

--- a/.github/workflows/scripts/stamp_dev_version.sh
+++ b/.github/workflows/scripts/stamp_dev_version.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+#
+# Appends a PEP 440 dev segment to tenseal/version.py, e.g. 0.3.17 -> 0.3.17.dev42.
+#
+# Both PyPI and TestPyPI refuse to overwrite an existing version, so without a
+# unique version each rehearsal after the first would either fail outright or,
+# with --skip-existing, silently upload nothing and prove nothing. Used only for
+# TestPyPI rehearsals; real releases publish the version as committed.
+
+set -e
+
+python - <<'PY'
+import os
+import pathlib
+import re
+
+path = pathlib.Path("tenseal/version.py")
+current = re.search(r'__version__ = "([^"]+)"', path.read_text()).group(1)
+stamped = "{}.dev{}".format(current, os.environ["GITHUB_RUN_NUMBER"])
+path.write_text('__version__ = "{}"\n'.format(stamped))
+print("stamped {} -> {}".format(current, stamped))
+PY


### PR DESCRIPTION
Restructures the publish workflow into `build -> verify -> publish`, and adds an opt-in TestPyPI rehearsal.

> **Depends on #521** — the sdist needs the `MANIFEST.in` added there. CI here will fail until that merges.

- **One upload per release.** Each of the 12 matrix cells currently runs `twine upload` itself, so a failure partway through leaves a half-published release. The matrix now only uploads artifacts; a single `publish` job does one upload.
- **Ships an sdist.** Only wheels are published today, so `pip install tenseal` on any unlisted platform simply fails.
- **Builds a wheel *from* the sdist** and imports it — the only check that catches an incomplete `MANIFEST.in`. An sdist missing `CMakeLists.txt`, `cmake/` or the `.proto` files still passes `twine check`, then fails for everyone building from source.
- **Triggers on `release: published`**, keeping `workflow_dispatch`.
- **TestPyPI rehearsal** (dispatch-only, the default): publishes, then installs back on all three platforms and runs a real CKKS op. `--extra-index-url` is required, as TestPyPI has no numpy.
- `stamp_dev_version.sh` appends `.dev<run_number>` for rehearsals only — both indexes refuse to overwrite an existing version.

Real releases are unaffected: `release: published` always targets PyPI with the existing `PYPI_USERNAME`/`PYPI_PASSWORD` secrets.