### PR TITLE
ci: build and publish musllinux wheels

### DIFF
--- a/.github/workflows/publish_wheels.yml
+++ b/.github/workflows/publish_wheels.yml
@@ -25,6 +25,7 @@ jobs:
       matrix:
         target:
           - [ubuntu-24.04, manylinux_x86_64, ""]
+          - [ubuntu-24.04, musllinux_x86_64, ""]
           - [windows-2022, win_amd64, ""]
           - [macos-14, macosx_arm64, "14.0"]
         python:
@@ -63,6 +64,7 @@ jobs:
         uses: pypa/cibuildwheel@298ed2fb2c105540f5ed055e8a6ad78d82dd3a7e # v3.3.1
         env:
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
+          CIBW_MUSLLINUX_X86_64_IMAGE: musllinux_1_2
           MACOSX_DEPLOYMENT_TARGET: ${{ matrix.target[2] }}
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.target[1] }}
           CIBW_BUILD_VERBOSITY: 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,14 +79,18 @@ jobs:
           CIBW_TEST_COMMAND: >-
             pytest -m "not slow" -v {project}/tests/python/tenseal &&
             pytest -v {project}/tests/python/sealapi
+          # Bound the parallelism. An unbounded `make -j` starts one compiler per
+          # ready target, and the heaviest translation unit peaks above 1 GB, so
+          # the burst can exhaust a runner and kill the agent mid-build. The
+          # runners have 4 vCPUs (macOS has 3), so -j4 costs no wall time.
           CIBW_TEST_COMMAND_LINUX: >-
             pytest -m "not slow" -v {project}/tests/python/tenseal &&
             pytest -v {project}/tests/python/sealapi &&
-            sh -c "cd {project} && CMAKE_POLICY_VERSION_MINIMUM=3.5 cmake . -D BUILD_TEST=TRUE && make -j && CTEST_OUTPUT_ON_FAILURE=1 make test"
+            sh -c "cd {project} && CMAKE_POLICY_VERSION_MINIMUM=3.5 cmake . -D BUILD_TEST=TRUE && make -j4 && CTEST_OUTPUT_ON_FAILURE=1 make test"
           CIBW_TEST_COMMAND_MACOS: >-
             pytest -m "not slow" -v {project}/tests/python/tenseal &&
             pytest -v {project}/tests/python/sealapi &&
-            sh -c "cd {project} && CMAKE_POLICY_VERSION_MINIMUM=3.5 cmake . -D BUILD_TEST=TRUE && make -j && CTEST_OUTPUT_ON_FAILURE=1 make test"
+            sh -c "cd {project} && CMAKE_POLICY_VERSION_MINIMUM=3.5 cmake . -D BUILD_TEST=TRUE && make -j4 && CTEST_OUTPUT_ON_FAILURE=1 make test"
         with:
           package-dir: .
           output-dir: wheelhouse

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,7 @@ jobs:
       matrix:
         target:
           - [ubuntu-24.04, manylinux_x86_64, ""]
+          - [ubuntu-24.04, musllinux_x86_64, ""]
           - [windows-2022, win_amd64, ""]
           - [macos-14, macosx_arm64, "14.0"]
         python:
@@ -63,6 +64,7 @@ jobs:
         uses: pypa/cibuildwheel@298ed2fb2c105540f5ed055e8a6ad78d82dd3a7e # v3.3.1
         env:
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
+          CIBW_MUSLLINUX_X86_64_IMAGE: musllinux_1_2
           MACOSX_DEPLOYMENT_TARGET: ${{ matrix.target[2] }}
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.target[1] }}
           CIBW_BUILD_VERBOSITY: 1

--- a/README.md
+++ b/README.md
@@ -95,9 +95,14 @@ Prebuilt wheels are published for every supported Python version on:
 
 | Platform | Wheel |
 | --- | --- |
-| Linux (x86-64) | `manylinux_2_28_x86_64` |
+| Linux, glibc (x86-64) | `manylinux_2_28_x86_64` |
+| Linux, musl (x86-64) | `musllinux_1_2_x86_64` |
 | macOS (Apple Silicon) | `macosx_14_0_arm64` |
 | Windows (x64) | `win_amd64` |
+
+Linux wheels come in two flavours: `manylinux` for glibc-based distributions and
+`musllinux` for musl-based ones such as Alpine, including the `-alpine` container
+images. pip picks the right one for your platform automatically.
 
 A source distribution is published as well, so `pip install tenseal` also works on platforms without a prebuilt wheel — it will compile from source, which needs the build requirements listed below. If your platform is missing a wheel you would like us to publish, please open an [issue](https://github.com/OpenMined/TenSEAL/issues).
 

--- a/cmake/tests.cmake
+++ b/cmake/tests.cmake
@@ -20,6 +20,12 @@ if(${BUILD_TEST})
       ${TENSEAL_TESTS_BASEDIR}/tensors/bfvtensor_test.cpp)
   add_executable(tenseal_tests ${TESTING_SOURCES} ${SOURCES})
   target_link_libraries(tenseal_tests PRIVATE gtest gtest_main seal)
-  target_link_libraries(tenseal_tests PRIVATE tenseal tenseal_proto)
+  # Do not link libtenseal.so here. It is built from the same ${SOURCES} and
+  # embeds the static SEAL library, so linking it alongside `seal` above gives
+  # the test binary two copies of SEAL's global memory pool. Both are destroyed
+  # at exit, and the second destruction segfaults. glibc hides this by having
+  # the executable's symbols interpose over the shared library's; musl resolves
+  # them independently, so the crash is visible there.
+  target_link_libraries(tenseal_tests PRIVATE tenseal_proto)
   add_test(tenseal_tests tenseal_tests)
 endif()


### PR DESCRIPTION
Issue #526 shows the problem. We publish glibc wheels only. On musl-based distributions, `pip install tenseal` finds no wheel and builds from source instead.

**1. Publish musllinux wheels.** Add `musllinux_x86_64` to the matrix in `tests.yml` and `publish_wheels.yml`, and pin `CIBW_MUSLLINUX_X86_64_IMAGE: musllinux_1_2`. The image has the same toolchain as manylinux, so the build needs no other change.

**2. Link SEAL one time in the C++ test binary.** `cmake/tests.cmake` linked the static `seal` library into `tenseal_tests`. It also linked `libtenseal.so`, which contains the same static SEAL. The test binary then held two copies of SEAL's global memory pool. Both copies are destroyed at exit, and the second destruction reads freed memory:

```
#0  std::shared_ptr<seal::util::MemoryPool>::~shared_ptr()
#1  __funcs_on_exit () at src/exit/atexit.c:34
```

glibc hides this, because the executable's symbols have priority over the shared library's symbols. musl keeps both copies. The bug is old. This pull request is the first change that runs the C++ tests on musl.

**3. Bound make parallelism.** The fix above removed a build-graph edge, so `make -j` started 44 compilers instead of 31. The largest translation unit needs more than 1 GB, and the burst killed the runner. Both the Linux and the macOS commands now use `make -j4`.

All 17 jobs pass. The musl cp314 cell changed from a segfault to a pass. macOS returned to 22 minutes from 39 minutes.

Cost: each matrix increases from 12 to 16 cells.

Follow-up, not in this pull request: `${SOURCES}` is compiled three times. An `OBJECT` library shared by the three targets would remove about a third of the compile work.
