### PR TITLE
ci: build and publish manylinux_aarch64 wheels

### DIFF
--- a/.github/workflows/publish_wheels.yml
+++ b/.github/workflows/publish_wheels.yml
@@ -26,6 +26,7 @@ jobs:
         target:
           - [ubuntu-24.04, manylinux_x86_64, ""]
           - [ubuntu-24.04, musllinux_x86_64, ""]
+          - [ubuntu-24.04-arm, manylinux_aarch64, ""]
           - [windows-2022, win_amd64, ""]
           - [macos-14, macosx_arm64, "14.0"]
         python:
@@ -65,6 +66,7 @@ jobs:
         env:
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
           CIBW_MUSLLINUX_X86_64_IMAGE: musllinux_1_2
+          CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
           MACOSX_DEPLOYMENT_TARGET: ${{ matrix.target[2] }}
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.target[1] }}
           CIBW_BUILD_VERBOSITY: 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,7 @@ jobs:
         target:
           - [ubuntu-24.04, manylinux_x86_64, ""]
           - [ubuntu-24.04, musllinux_x86_64, ""]
+          - [ubuntu-24.04-arm, manylinux_aarch64, ""]
           - [windows-2022, win_amd64, ""]
           - [macos-14, macosx_arm64, "14.0"]
         python:
@@ -65,6 +66,7 @@ jobs:
         env:
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
           CIBW_MUSLLINUX_X86_64_IMAGE: musllinux_1_2
+          CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
           MACOSX_DEPLOYMENT_TARGET: ${{ matrix.target[2] }}
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.target[1] }}
           CIBW_BUILD_VERBOSITY: 1

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Prebuilt wheels are published for every supported Python version on:
 | --- | --- |
 | Linux, glibc (x86-64) | `manylinux_2_28_x86_64` |
 | Linux, musl (x86-64) | `musllinux_1_2_x86_64` |
+| Linux, glibc (aarch64) | `manylinux_2_28_aarch64` |
 | macOS (Apple Silicon) | `macosx_14_0_arm64` |
 | Windows (x64) | `win_amd64` |
 


### PR DESCRIPTION
## Description

Adds a native ubuntu-24.04-arm runner to both the Build and Publish workflows, mirroring the musllinux_x86_64 entry added in #528. 

## Affected Dependencies
none


## How has this been tested?
- Describe the tests that you ran to verify your changes.

  - This is a CI-only change (adds an ubuntu-24.04-arm job to the Build/Publish matrix). Verified by pushing the branch and letting the Tests workflow run on GitHub Actions — the new manylinux_aarch64 job built the wheel and ran the test suite on the native ARM runner, and it passed

- Provide instructions so we can reproduce.
  - no applicable

- List any relevant details for your test configuration.
  - Runner: ubuntu-24.04-arm (native, not emulated)
  - CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
  - SEAL_USE_INTEL_HEXL OFF (no x86 intrinsics dependency)
   - Same Python version matrix as the existing manylinux_x86_64/musllinux_x86_64 jobs

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
