### PR TITLE
fix(ci): name wheel artifacts by platform tag, not runner label

### DIFF
--- a/.github/workflows/publish_wheels.yml
+++ b/.github/workflows/publish_wheels.yml
@@ -76,10 +76,15 @@ jobs:
           package-dir: .
           output-dir: wheelhouse
 
+      # Name the artifact after the platform tag, not the runner label. Several
+      # rows share a runner (manylinux and musllinux both build on ubuntu-24.04),
+      # so keying on the label makes their artifacts collide. The upload still
+      # succeeds, but `download-artifact` with merge-multiple then extracts them
+      # over each other and the publish job silently ships one platform short.
       - name: Upload wheel artifact
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
-          name: dist-wheel-${{ matrix.python }}-${{ matrix.target[0] }}
+          name: dist-wheel-${{ matrix.python }}-${{ matrix.target[1] }}
           path: ./wheelhouse/*.whl
 
   build_sdist:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,7 +2,8 @@
 
 Releases are built and published by the **Build and Publish** workflow
 ([`.github/workflows/publish_wheels.yml`](.github/workflows/publish_wheels.yml)).
-It produces 12 wheels — Python 3.11–3.14 for Linux, macOS (arm64) and Windows —
+It produces 16 wheels — Python 3.11–3.14 for Linux (glibc and musl), macOS (arm64)
+and Windows —
 plus a source distribution, and uploads them in a single step so a partial
 failure cannot leave a half-published release on the index.
 
@@ -65,7 +66,7 @@ for approval; the build jobs run first regardless.
 pip index versions tenseal
 ```
 
-Or check [the project page](https://pypi.org/project/tenseal/) for 12 wheels and
+Or check [the project page](https://pypi.org/project/tenseal/) for 16 wheels and
 one `.tar.gz`. Update [`CHANGELOG.md`](CHANGELOG.md) if it was not part of the
 version bump.
 


### PR DESCRIPTION
The wheel artifact name used the runner label. Two matrix rows share `ubuntu-24.04`, so manylinux and musllinux both uploaded as `dist-wheel-<py>-ubuntu-24.04`. The uploads succeed. But `download-artifact` with `merge-multiple` extracts artifacts with the same name over each other, so the publish job ships one platform less and still reports success.

TestPyPI [`0.3.17.dev6`](https://test.pypi.org/project/tenseal/0.3.17.dev6/#files) shows the result: 13 files, not 17, and no manylinux wheels. The rehearsal before musllinux (`dev4`) also had 13 files, but with manylinux. The new platform replaced a platform instead of adding one.

- Name the artifact after `matrix.target[1]`, the platform tag. It is unique for each row, and the job name and `CIBW_BUILD` already use it
- Correct the wheel counts in `RELEASING.md` from 12 to 16. That count is the check which must catch this problem

The matrix gives 16 artifact names, and all 16 are unique. The names stay unique with the `manylinux_aarch64` row from #529: 20 names, 20 unique.

`tests.yml` cannot verify this fix, because it uploads no artifacts. Use a TestPyPI rehearsal. Expect 17 files, and `manylinux_2_28_x86_64` must be present.

Released versions are correct. v0.3.17 is older than musllinux, so its 12 wheels are complete. Only a release after #528 loses manylinux.